### PR TITLE
feat: generate static properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ export default class TestStore extends VuexModule {
 
 ### Type safety
 
-When using the default way of accessing the vuex store, you never know eg. what type the getter returns or what payload the action accepts. Thats why we automatically create static properties on every vuex module you create which can be access by passing the store through the `getModule` method. If we take the store we described above, you can do something like this:
+When using the default way of accessing the vuex store, you never know eg. what type the getter returns or what payload the action accepts. Thats why we automatically create static properties on every vuex module you create which can be accessed by passing the store through the `getModule` method. If we take the store we described above, you can do something like this:
 
 ```vue
 <template>
@@ -170,7 +170,6 @@ When using the default way of accessing the vuex store, you never know eg. what 
 
 <script type="ts">
     import { Vue, Component } from 'vue-property-decorator';
-    import { getModule } from '@averjs/vuex-decorators';
     import TestStore from './TestStore';
     import { getModule } from '@averjs/vuex-decorators';
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,5 @@ module.exports = {
   clearMocks: true,
   coverageDirectory: 'coverage',
   collectCoverage: true,
-  preset: 'ts-jest',
-  testEnvironment: 'node'
+  preset: 'ts-jest'
 };

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@types/jest": "25.2.2",
+    "@vue/test-utils": "^1.0.3",
     "codecov": "3.6.5",
     "jest": "26.0.1",
     "prettier": "2.0.5",
@@ -46,6 +47,7 @@
     "tslint-plugin-prettier": "^2.3.0",
     "typescript": "3.9.2",
     "vue": "2.6.11",
+    "vue-template-compiler": "^2.6.11",
     "vuex": "3.4.0"
   }
 }

--- a/src/decorators/StaticGenerators.ts
+++ b/src/decorators/StaticGenerators.ts
@@ -1,0 +1,82 @@
+import { config, AverModule } from './utils';
+import { GetterTree, MutationTree, ActionTree } from 'vuex';
+
+export type ConstructorOf<C> = { new (...args: any[]): C };
+
+export interface PropertiesToDefine {
+  [key: string]: PropertyDescriptor & ThisType<any>;
+}
+
+export function generateStaticStates<S, R>(
+  store: AverModule<S, R>,
+  propertiesToDefine: PropertiesToDefine
+): PropertiesToDefine {
+  for (const state of Object.keys((store.state as () => S)())) {
+    propertiesToDefine[state] = {
+      get() {
+        return config.store?.state[store.moduleName as string][state];
+      },
+    };
+  }
+
+  return propertiesToDefine;
+}
+
+export function generateStaticGetters<S, R>(
+  store: AverModule<S, R>,
+  propertiesToDefine: PropertiesToDefine
+): PropertiesToDefine {
+  for (const getter of Object.keys(store.getters as GetterTree<S, R>)) {
+    propertiesToDefine[getter] = {
+      get() {
+        return config.store?.getters[`${store.moduleName}/${getter}`];
+      },
+    };
+  }
+
+  return propertiesToDefine;
+}
+
+export function generateStaticMutations<S, R>(
+  store: AverModule<S, R>,
+  propertiesToDefine: PropertiesToDefine
+): PropertiesToDefine {
+  for (const mutation of Object.keys(store.mutations as MutationTree<S>)) {
+    if (propertiesToDefine[mutation]) {
+      const temp = propertiesToDefine[mutation];
+      propertiesToDefine[mutation] = {
+        ...temp,
+        set: (val: any) => {
+          config.store?.commit(`${store.moduleName}/${mutation}`, val);
+        },
+      };
+    } else {
+      propertiesToDefine[mutation] = {
+        value: (val: any) => {
+          config.store?.commit(`${store.moduleName}/${mutation}`, val);
+        },
+      };
+    }
+  }
+
+  return propertiesToDefine;
+}
+
+export function generateStaticActions<S, R>(
+  store: AverModule<S, R>,
+  propertiesToDefine: PropertiesToDefine
+): PropertiesToDefine {
+  for (const action of Object.keys(store.actions as ActionTree<S, R>)) {
+    propertiesToDefine[action] = {
+      value: async (val: any) => {
+        return config.store?.dispatch(`${store.moduleName}/${action}`, val);
+      },
+    };
+  }
+
+  return propertiesToDefine;
+}
+
+export function getModule<S>(module: ConstructorOf<S>): S {
+  return module as any;
+}

--- a/src/decorators/VuexClass.ts
+++ b/src/decorators/VuexClass.ts
@@ -1,43 +1,68 @@
 import ExportVuexStore from './ExportVuexStore';
 import { stores, assignStates, getClassName } from './utils';
 import { ActionContext } from 'vuex';
+import {
+  generateStaticStates,
+  generateStaticGetters,
+  generateStaticMutations,
+  generateStaticActions,
+} from './StaticGenerators';
 
 interface VuexClassOptions {
   persistent?: Array<string>;
   extend?: Array<any>;
 }
 
+function generateVuexClass<S, R>(options: VuexClassOptions) {
+  return <TFunction extends Function>(
+    constructor: TFunction
+  ): TFunction | void => {
+    const target: Function & VuexClassOptions = constructor;
+
+    assignStates(target);
+
+    const store = stores[getClassName(target)];
+
+    for (const obj of options?.extend || []) {
+      const extendStore = ExportVuexStore<any, any, typeof target>(obj);
+      const oldState = store.state();
+      const newState = extendStore.state();
+      const stateFactory = () => Object.assign(oldState, newState);
+      store.state = stateFactory;
+      Object.assign(store.getters, extendStore.getters);
+      Object.assign(store.actions, extendStore.actions);
+      Object.assign(store.mutations, extendStore.mutations);
+    }
+
+    if (options?.persistent) store.persistent = options.persistent;
+    else store.persistent = false;
+
+    const propertiesToDefine = {};
+
+    generateStaticStates(store, propertiesToDefine);
+    generateStaticGetters(store, propertiesToDefine);
+    generateStaticMutations(store, propertiesToDefine);
+    generateStaticActions(store, propertiesToDefine);
+
+    Object.defineProperties(constructor, propertiesToDefine);
+
+    return constructor;
+  };
+}
+
 export class VuexModule<S = ThisType<any>, R = any> {
   $store!: ActionContext<S, R>;
 }
 
-export function VuexClass<S>(module?: Function & VuexClassOptions): void;
-export function VuexClass<S>(options?: VuexClassOptions): ClassDecorator;
+export function VuexClass(module: Function & VuexClassOptions): void;
+export function VuexClass(options: VuexClassOptions): ClassDecorator;
 
-export function VuexClass<S>(
-  options?: VuexClassOptions | (Function & VuexClassOptions)
+export function VuexClass(
+  options: VuexClassOptions | (Function & VuexClassOptions)
 ) {
   if (typeof (options as any) === 'function') {
-    assignStates(options);
+    generateVuexClass({})(options as Function & VuexClassOptions);
   } else {
-    return (target: S) => {
-      assignStates(target);
-
-      const store = stores[getClassName(target)];
-
-      for (const obj of options?.extend || []) {
-        const extendStore = ExportVuexStore<any, any, typeof target>(obj);
-        const oldState = store.state();
-        const newState = extendStore.state();
-        const stateFactory = () => Object.assign(oldState, newState);
-        store.state = stateFactory;
-        Object.assign(store.getters, extendStore.getters);
-        Object.assign(store.actions, extendStore.actions);
-        Object.assign(store.mutations, extendStore.mutations);
-      }
-
-      if (options?.persistent) store.persistent = options.persistent;
-      else store.persistent = false;
-    };
+    return generateVuexClass(options);
   }
 }

--- a/src/decorators/utils.ts
+++ b/src/decorators/utils.ts
@@ -1,4 +1,4 @@
-import { Module, GetterTree, MutationTree } from 'vuex';
+import { Store as VuexStore, Module, GetterTree, MutationTree } from 'vuex';
 
 export interface AverModule<S, R> extends Module<S, R> {
   moduleName?: string;
@@ -8,6 +8,12 @@ export interface AverModule<S, R> extends Module<S, R> {
 interface Store<S, R> {
   [key: string]: AverModule<S, R>;
 }
+
+interface Config<S> {
+  store?: VuexStore<S>;
+}
+
+export const config: Config<any> = {};
 
 export const stores: Store<any, any> = {};
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import HasGetter from './decorators/HasGetter';
 import HasGetterAndMutation from './decorators/HasGetterAndMutation';
 import Mutation from './decorators/Mutation';
 import { VuexClass, VuexModule } from './decorators/VuexClass';
+import { getModule } from './decorators/StaticGenerators';
+import { config } from './decorators/utils';
 
 export {
   Action,
@@ -15,4 +17,6 @@ export {
   Mutation,
   VuexClass,
   VuexModule,
+  getModule,
+  config,
 };

--- a/test/ExportVuexStore.test.ts
+++ b/test/ExportVuexStore.test.ts
@@ -13,6 +13,7 @@ test('check if object is a valid vuex object', () => {
     actions: {},
     mutations: {},
     moduleName: 'testModule',
+    persistent: false,
   };
   expect(JSON.stringify(tm)).toEqual(JSON.stringify(obj));
   expect(tm.state).toEqual(expect.any(Function));

--- a/test/StaticGenerator.test.ts
+++ b/test/StaticGenerator.test.ts
@@ -1,0 +1,212 @@
+import Vuex, { Store } from 'vuex';
+import {
+  VuexClass,
+  ExportVuexStore,
+  Mutation,
+  HasGetterAndMutation,
+  Action,
+  VuexModule,
+  Getter,
+} from '../src';
+import { stores, config } from '../src/decorators/utils';
+import { createLocalVue, mount } from '@vue/test-utils';
+import {
+  getModule,
+  generateStaticStates,
+  PropertiesToDefine,
+  generateStaticGetters,
+  generateStaticMutations,
+  generateStaticActions,
+} from '../src/decorators/StaticGenerators';
+
+interface PayloadInterface {
+  test1: string;
+  test2?: string[];
+}
+
+@VuexClass
+class TestModule extends VuexModule {
+  private moduleName = 'testModule';
+
+  @HasGetterAndMutation public test = 'test';
+
+  /**
+   * Returns the char length of the test variable.
+   */
+  public get testCharCount(): number {
+    return this.test.length;
+  }
+
+  /**
+   * Returns the char length of the test variable times 2.
+   */
+  @Getter public testCharCountTimes2(): number {
+    return this.test.length * 2;
+  }
+
+  @Mutation public setTest(val: string) {
+    this.test = val;
+  }
+
+  @Action public async fetchTest(payload: PayloadInterface): Promise<boolean> {
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    this.$store.commit('setTest', payload.test1);
+    return true;
+  }
+}
+
+let module: TestModule;
+let store: Store<any>;
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+beforeEach(() => {
+  const testModule = ExportVuexStore(TestModule);
+
+  store = new Vuex.Store({
+    modules: {
+      [testModule.moduleName as string]: testModule,
+    },
+  });
+
+  config.store = store;
+
+  module = getModule(TestModule);
+});
+
+function wrapperFactory() {
+  return mount(
+    {
+      template:
+        '<div>{{ testCharCount }} {{ testCharCountTimes2 }} {{ test }}</div>',
+      computed: {
+        test() {
+          return module.test;
+        },
+        testCharCount() {
+          return module.testCharCount;
+        },
+        testCharCountTimes2() {
+          return module.testCharCountTimes2;
+        },
+      },
+    },
+    {
+      localVue,
+      store,
+    }
+  );
+}
+
+test('generated properties should be reactive', async () => {
+  const component = wrapperFactory();
+  expect(component.text()).toBe('4 8 test');
+
+  await module.fetchTest({ test1: 'hello' });
+  await component.vm.$nextTick();
+  expect(component.text()).toBe('5 10 hello');
+
+  module.test = 'world';
+  await component.vm.$nextTick();
+  expect(component.text()).toBe('5 10 world');
+
+  module.setTest('hello world!');
+  await component.vm.$nextTick();
+  expect(component.text()).toBe('12 24 hello world!');
+});
+
+test('should generate static states correctly', () => {
+  const propertiesToDefine: PropertiesToDefine = {};
+  generateStaticStates(stores.testModule, propertiesToDefine);
+  expect(JSON.stringify(propertiesToDefine)).toEqual(
+    JSON.stringify({
+      test: {
+        get() {},
+      },
+    })
+  );
+
+  expect(propertiesToDefine.test.get!()).toBe('test');
+  expect(module.test).toBe('test');
+});
+
+test('should generate static getters correctly', () => {
+  const propertiesToDefine: PropertiesToDefine = {};
+  generateStaticGetters(stores.testModule, propertiesToDefine);
+  expect(JSON.stringify(propertiesToDefine)).toEqual(
+    JSON.stringify({
+      test: {
+        get() {},
+      },
+      testCharCountTimes2: {
+        get() {},
+      },
+      testCharCount: {
+        get() {},
+      },
+    })
+  );
+
+  expect(propertiesToDefine.test.get!()).toBe('test');
+  expect(module.test).toBe('test');
+  expect(propertiesToDefine.testCharCount.get!()).toBe(4);
+  expect(module.testCharCount).toBe(4);
+  expect(propertiesToDefine.testCharCountTimes2.get!()).toBe(8);
+  expect(module.testCharCountTimes2).toBe(8);
+});
+
+test('should generate static mutations correctly', () => {
+  const propertiesToDefine: PropertiesToDefine = {};
+  generateStaticMutations(stores.testModule, propertiesToDefine);
+  expect(JSON.stringify(propertiesToDefine)).toEqual(
+    JSON.stringify({
+      test: {
+        set() {},
+      },
+      setTest: {
+        value() {},
+      },
+    })
+  );
+
+  propertiesToDefine.test.value!('test2');
+  expect(store.getters['testModule/test']).toBe('test2');
+  expect(module.test).toBe('test2');
+
+  propertiesToDefine.setTest.value!('test3');
+  expect(store.getters['testModule/test']).toBe('test3');
+  expect(module.test).toBe('test3');
+});
+
+test('should generate get and set for properties with HasGetterAndMutation', () => {
+  const propertiesToDefine: PropertiesToDefine = {};
+  generateStaticGetters(stores.testModule, propertiesToDefine);
+  generateStaticMutations(stores.testModule, propertiesToDefine);
+
+  propertiesToDefine.test.set!('test2');
+  expect(propertiesToDefine.test.get!()).toBe('test2');
+  expect(store.getters['testModule/test']).toBe('test2');
+  expect(module.test).toBe('test2');
+});
+
+test('should generate static actions correctly', async () => {
+  const propertiesToDefine: PropertiesToDefine = {};
+  generateStaticActions(stores.testModule, propertiesToDefine);
+  expect(JSON.stringify(propertiesToDefine)).toEqual(
+    JSON.stringify({
+      fetchTest: {
+        value() {},
+      },
+    })
+  );
+
+  let val = await propertiesToDefine.fetchTest.value({ test1: 'hello' });
+  expect(val).toBeTruthy();
+  expect(store.getters['testModule/test']).toBe('hello');
+  expect(module.test).toBe('hello');
+
+  val = await module.fetchTest({ test1: 'world' });
+  expect(val).toBeTruthy();
+  expect(store.getters['testModule/test']).toBe('world');
+  expect(module.test).toBe('world');
+});

--- a/test/StaticGenerator.test.ts
+++ b/test/StaticGenerator.test.ts
@@ -30,6 +30,14 @@ class TestModule extends VuexModule {
 
   @HasGetterAndMutation public test = 'test';
 
+  get getSetTest() {
+    return this.test;
+  }
+
+  set getSetTest(val) {
+    this.test = val;
+  }
+
   /**
    * Returns the char length of the test variable.
    */
@@ -141,6 +149,9 @@ test('should generate static getters correctly', () => {
       testCharCountTimes2: {
         get() {},
       },
+      getSetTest: {
+        get() {},
+      },
       testCharCount: {
         get() {},
       },
@@ -158,6 +169,7 @@ test('should generate static getters correctly', () => {
 test('should generate static mutations correctly', () => {
   const propertiesToDefine: PropertiesToDefine = {};
   generateStaticMutations(stores.testModule, propertiesToDefine);
+
   expect(JSON.stringify(propertiesToDefine)).toEqual(
     JSON.stringify({
       test: {
@@ -165,6 +177,9 @@ test('should generate static mutations correctly', () => {
       },
       setTest: {
         value() {},
+      },
+      getSetTest: {
+        set() {},
       },
     })
   );

--- a/test/VuexClass.test.ts
+++ b/test/VuexClass.test.ts
@@ -58,7 +58,7 @@ test('persistent class option should be undefined when not set', () => {
 
   const tm = ExportVuexStore(TestModule);
 
-  expect(tm.persistent).toBe(undefined);
+  expect(tm.persistent).toBeFalsy();
 });
 
 test('class should inherit from given class in extend option', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -831,6 +831,15 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@vue/test-utils@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-1.0.3.tgz#587c4dd9b424b66022f188c19bc605da2ce91c6f"
+  integrity sha512-mmsKXZSGfvd0bH05l4SNuczZ2MqlJH2DWhiul5wJXFxbf/gRRd2UL4QZgozEMQ30mRi9i4/+p4JJat8S4Js64Q==
+  dependencies:
+    dom-event-types "^1.0.0"
+    lodash "^4.17.15"
+    pretty "^2.0.0"
+
 JSONStream@^1.0.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -843,6 +852,11 @@ abab@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
   integrity sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==
+
+abbrev@1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
+  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
 acorn-globals@^6.0.0:
   version "6.0.0"
@@ -1370,7 +1384,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.12.1, commander@~2.20.3:
+commander@^2.12.1, commander@^2.19.0, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -1407,6 +1421,23 @@ concat-stream@^2.0.0:
     inherits "^2.0.3"
     readable-stream "^3.0.2"
     typedarray "^0.0.6"
+
+condense-newlines@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/condense-newlines/-/condense-newlines-0.2.1.tgz#3de985553139475d32502c83b02f60684d24c55f"
+  integrity sha1-PemFVTE5R10yUCyDsC9gaE0kxV8=
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-whitespace "^0.3.0"
+    kind-of "^3.0.2"
+
+config-chain@^1.1.12:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.12.tgz#0fde8d091200eb5e808caf25fe618c02f48e4efa"
+  integrity sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==
+  dependencies:
+    ini "^1.3.4"
+    proto-list "~1.2.1"
 
 conventional-changelog-angular@^5.0.6:
   version "5.0.10"
@@ -1679,6 +1710,11 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
+de-indent@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
+  integrity sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=
+
 debug@4, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
@@ -1786,6 +1822,11 @@ doctrine@0.7.2:
     esutils "^1.1.6"
     isarray "0.0.1"
 
+dom-event-types@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/dom-event-types/-/dom-event-types-1.0.0.tgz#5830a0a29e1bf837fe50a70cd80a597232813cae"
+  integrity sha512-2G2Vwi2zXTHBGqXHsJ4+ak/iP0N8Ar+G8a7LiD2oup5o4sQWytwqqrZu/O6hIMV0KMID2PL69OhpshLO0n7UJQ==
+
 domexception@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-2.0.1.tgz#fb44aefba793e1574b0af6aed2801d057529f304"
@@ -1815,6 +1856,16 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+editorconfig@^0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.15.3.tgz#bef84c4e75fb8dcb0ce5cee8efd51c15999befc5"
+  integrity sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==
+  dependencies:
+    commander "^2.19.0"
+    lru-cache "^4.1.5"
+    semver "^5.6.0"
+    sigmund "^1.0.1"
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -2353,6 +2404,11 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
+he@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
 hosted-git-info@^2.1.4:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
@@ -2463,7 +2519,7 @@ inherits@^2.0.3, inherits@~2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ini@^1.3.2:
+ini@^1.3.2, ini@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -2628,6 +2684,11 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
+
+is-whitespace@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/is-whitespace/-/is-whitespace-0.3.0.tgz#1639ecb1be036aec69a54cbb401cfbed7114ab7f"
+  integrity sha1-Fjnssb4DauxppUy7QBz77XEUq38=
 
 is-windows@^1.0.2:
   version "1.0.2"
@@ -3095,6 +3156,17 @@ jest@26.0.1:
     import-local "^3.0.2"
     jest-cli "^26.0.1"
 
+js-beautify@^1.6.12:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.11.0.tgz#afb873dc47d58986360093dcb69951e8bcd5ded2"
+  integrity sha512-a26B+Cx7USQGSWnz9YxgJNMmML/QG2nqIaL7VVYPCXbqiKz8PN0waSNvroMtvAK6tY7g/wPdNWGEP+JTNIBr6A==
+  dependencies:
+    config-chain "^1.1.12"
+    editorconfig "^0.15.3"
+    glob "^7.1.3"
+    mkdirp "~1.0.3"
+    nopt "^4.0.3"
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -3355,6 +3427,14 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
+lru-cache@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 make-dir@^3.0.0, make-dir@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.0.2.tgz#04a1acbf22221e1d6ef43559f43e05a90dbb4392"
@@ -3562,7 +3642,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@1.x:
+mkdirp@1.x, mkdirp@~1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -3647,6 +3727,14 @@ node-notifier@^7.0.0:
     shellwords "^0.1.1"
     uuid "^7.0.3"
     which "^2.0.2"
+
+nopt@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.3.tgz#a375cad9d02fd921278d954c2254d5aa57e15e48"
+  integrity sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==
+  dependencies:
+    abbrev "1"
+    osenv "^0.1.4"
 
 normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.5, normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -3757,6 +3845,24 @@ optionator@^0.8.1:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     wordwrap "~1.0.0"
+
+os-homedir@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
+  integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
+
+os-tmpdir@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+  integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
+
+osenv@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
+  integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
+  dependencies:
+    os-homedir "^1.0.0"
+    os-tmpdir "^1.0.0"
 
 p-each-series@^2.1.0:
   version "2.1.0"
@@ -3987,6 +4093,15 @@ pretty-format@^26.0.1:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
+pretty@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pretty/-/pretty-2.0.0.tgz#adbc7960b7bbfe289a557dc5f737619a220d06a5"
+  integrity sha1-rbx5YLe7/iiaVX3F9zdhmiINBqU=
+  dependencies:
+    condense-newlines "^0.2.1"
+    extend-shallow "^2.0.1"
+    js-beautify "^1.6.12"
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -3999,6 +4114,16 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.2"
     sisteransi "^1.0.0"
+
+proto-list@~1.2.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
+  integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
+
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
 psl@^1.1.28:
   version "1.1.31"
@@ -4348,7 +4473,7 @@ saxes@^5.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -4435,6 +4560,11 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
+sigmund@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
+  integrity sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
@@ -5148,6 +5278,14 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+vue-template-compiler@^2.6.11:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.11.tgz#c04704ef8f498b153130018993e56309d4698080"
+  integrity sha512-KIq15bvQDrcCjpGjrAhx4mUlyyHfdmTaoNfeoATHLAiWB+MU3cx4lOzMwrnUh9cCxy0Lt1T11hAFY6TQgroUAA==
+  dependencies:
+    de-indent "^1.0.2"
+    he "^1.1.0"
+
 vue@2.6.11:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.11.tgz#76594d877d4b12234406e84e35275c6d514125c5"
@@ -5282,6 +5420,11 @@ y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yargs-parser@18.x, yargs-parser@^18.1.1:
   version "18.1.2"


### PR DESCRIPTION
This feature generates static properties which can be called without making an instance of the class. By calling the new method `getModule`, you get correct typings for every property you defined inside the class.

```ts
// TestModule.ts
import {
  VuexClass,
  Mutation,
  HasGetterAndMutation,
  Action,
  VuexModule,
  Getter,
} from '@averjs/vuex-decorators';

interface PayloadInterface {
  test1: string;
  test2?: string[];
}

@VuexClass
export default class TestModule extends VuexModule {
  private moduleName = 'testModule';

  @HasGetterAndMutation public test = 'test';

  /**
   * Returns the char length of the test variable.
   */
  public get testCharCount(): number {
    return this.test.length;
  }

  /**
   * Returns the char length of the test variable times 2.
   */
  @Getter public testCharCountTimes2(): number {
    return this.test.length * 2;
  }

  @Mutation public setTest(val: string) {
    this.test = val;
  }

  @Action public async fetchTest(payload: PayloadInterface): Promise<boolean> {
    await new Promise((resolve) => setTimeout(resolve, 200));
    this.$store.commit('setTest', payload.test1);
    return true;
  }
}
```

```vue
<template>
    <div @click="callAction">{{ test }}</div>
</template>

<script lang="ts">
    import { Vue, Component } from 'vue-property-decorator';
    import { getModule } from '@averjs/vuex-decorators';
    import Module from './TestModule.ts';
    const TestModule = getModule(Module);

    @Component
    export default class Test extends Vue {
        get test() {
            return TestModule.test;
        }

        set test(val) {
            TestModule.test = val;
        }

        async callAction() {
            await TestModule.fetchTest({ test1: 'hello world!' });
        }
    }
</script>
```