### PR TITLE
fix: do not use else if for getter and setter

### DIFF
--- a/src/decorators/utils.ts
+++ b/src/decorators/utils.ts
@@ -54,7 +54,8 @@ export function assignStates<S>(Obj: any) {
         const output = (descriptor.get as Function).call(thisObject);
         return output;
       };
-    } else if (descriptor && descriptor.set) {
+    }
+    if (descriptor && descriptor.set) {
       mutations[func] = (state: S, payload: any) => {
         (descriptor.set as Function).call(state, payload);
       };


### PR DESCRIPTION
If getter and setter are defined, with `else if` the setter would never be defined.