### PR TITLE
feat: this context inside class

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -12,6 +12,7 @@ Thanks to Decorators in Typescript and Babel, we are able to transform the borin
 - Works with Babel and Typescript
 - Type-safe way of accessing the store with static class properties
 - Nested modules with namespace awareness (There is no limit 👌)
+- Support for SSR
 
 ## Transpiler Setup
 

--- a/docs/type-safety/README.md
+++ b/docs/type-safety/README.md
@@ -1,6 +1,12 @@
 # Type Safety
 
-When using the default way of accessing the vuex store, you never know eg. what type the getter returns or what payload the action accepts. Thats why we automatically create static properties on every vuex module you create which can be accessed by passing the store through the `getModule` method.
+::: warning
+Everything shown below assumes that you passed the final store to `config.store`. You can see how it is done [here](/api/config/#store).
+:::
+
+## How to use it
+
+When using the default way of accessing the vuex store, you never know eg. what type the getter returns or what payload the action accepts. Thats why we automatically create static properties on every vuex module you create and pass through the `ExportVuexStore` function, which can be accessed by passing the store through the `getModule` method.
 
 First we need a basic vuex module.
 
@@ -10,7 +16,7 @@ import axios from 'axios';
 
 @VuexClass
 export default class TestStore extends VuexModule {
-  moduleName = 'test';
+  private moduleName = 'test';
 
   @HasGetterAndMutation test = 'test';
 
@@ -73,3 +79,115 @@ What happens internally is that the `@VuexClass` decorator modifies the class by
 ```
 
 This feature is not limited to Typescript. It can also be used with Babel. Even though it will not give you precise typings, your IDEs intellisense will still tell you what can be called inside your vuex module.
+
+## `this` context
+
+In the example above, you can see that inside the action, in order to mutate a state, we used `this.$store`. This elminiates typings and can be prone to errors. To make DX even better, you can call every action, mutation, ... by using `this`, like you would do in a normal class. This also works with nested stores. The example above could look something like this.
+
+```typescript{40,41,42,43,44,54,56}
+import {
+  VuexClass,
+  VuexModule,
+  Action,
+  HasGetterAndMutation,
+  Nested,
+  Mutation,
+  Getter
+} from '@averjs/vuex-decorators';
+import axios from 'axios';
+
+@VuexClass
+class NestedStore extends VuexModule {
+  private moduleName = 'nested';
+  nestedState = 'nested';
+
+  get lazyNestedState() { return this.nestedState; }
+}
+
+@VuexClass
+export default class TestStore extends VuexModule {
+  private moduleName = 'test';
+
+  @Nested() nested = new NestedStore();
+
+  @HasGetterAndMutation test = 'test';
+
+  get lazyTest() { return this.test }
+  set lazyTest(val) { this.test = val; }
+
+  @Getter getTest() {
+    return this.test;
+  }
+
+  @Mutation setTest(val) {
+    this.test = val;
+  }
+
+  @Action async anotherAction() {
+    this.setTest('hello');
+    console.log(this.getTest());
+    this.lazyTest = 'world';
+    console.log(this.lazyTest);
+    console.log(this.nested.lazyNestedState);
+  }
+
+  @Action async fetchSomething({ data }) {
+    const { data: { test } } = await axios({
+      url: `test`,
+      method: 'GET',
+      data
+    });
+
+    this.test = test;
+
+    await this.anotherAction();
+  }
+}
+```
+
+You can see that everything is callable as it was defined. Eg. the `@Getter` was defined as a function and can be called like that.
+
+One thing you still have to keep in mind is that, we still follow the recommended vuex way. That means, you can only call the stuff that would be passed as context.
+
+For `getters`:
+- state
+- getters
+
+For `actions`:
+- state
+- mutations
+- getters
+- actions
+
+## root access
+
+`actions` and `getters` both are having access to `rootState` and `rootGetters`. When you decide you want to go with the complete `Type Safe` way and also not using `this.$store` inside the module classes, it would be a bummer if you would have to use `this.$store` only to access root stuff. To solve that problem, you dont need to learn anything new, just import the store classes you passed through the `getModule` function and call it inside your actions or wherever you want.
+
+```typescript
+import { VuexClass, VuexModule, HasGetterAndMutation, getModule } from '@averjs/vuex-decorators';
+import axios from 'axios';
+
+@VuexClass
+export default class AnyStore extends VuexModule {
+  private moduleName = 'anyStore';
+  @HasGetterAndMutation test = 'hello world';
+}
+
+export const AnyModule = getModule(AnyStore);
+```
+
+```typescript
+import { VuexClass, VuexModule, Action, HasGetterAndMutation } from '@averjs/vuex-decorators';
+import { AnyModule } from './AnyStore';
+
+@VuexClass
+export default class TestStore extends VuexModule {
+  private moduleName = 'test';
+
+  @HasGetterAndMutation test = 'test';
+
+  @Action async fetchSomething() {
+    this.test = AnyModule.test;
+  }
+}
+```

--- a/docs/type-safety/README.md
+++ b/docs/type-safety/README.md
@@ -6,7 +6,7 @@ Everything shown below assumes that you passed the final store to `config.store`
 
 ## How to use it
 
-When using the default way of accessing the vuex store, you never know eg. what type the getter returns or what payload the action accepts. Thats why we automatically create static properties on every vuex module you create and pass through the `ExportVuexStore` function, which can be accessed by passing the store through the `getModule` method.
+When using the default way of accessing the vuex store, you never know eg. what type the getter returns or what payload the action accepts. Thats why we automatically create static properties on every vuex module you create and pass through the `ExportVuexStore` function. Before we are ready to access the static properties, we need to pass the class to the `getModule` function, which returns the static properties.
 
 First we need a basic vuex module.
 
@@ -82,7 +82,7 @@ This feature is not limited to Typescript. It can also be used with Babel. Even 
 
 ## `this` context
 
-In the example above, you can see that inside the action, in order to mutate a state, we used `this.$store`. This elminiates typings and can be prone to errors. To make DX even better, you can call every action, mutation, ... by using `this`, like you would do in a normal class. This also works with nested stores. The example above could look something like this.
+In the example above, you can see that inside the action, in order to mutate a state, we used `this.$store`. This eliminates typings and can be prone to errors. To make DX even better, you can call every action, mutation, ... by using `this`, like you would do in a normal class. This also works with nested stores. The example above could look something like this.
 
 ```typescript{40,41,42,43,44,54,56}
 import {

--- a/docs/type-safety/README.md
+++ b/docs/type-safety/README.md
@@ -147,7 +147,7 @@ export default class TestStore extends VuexModule {
 
 You can see that everything is callable as it was defined. Eg. the `@Getter` was defined as a function and can be called like that.
 
-One thing you still have to keep in mind is that, we still follow the recommended vuex way. That means, you can only call the stuff that would be passed as context.
+One thing you still have to keep in mind is that we still follow the recommended vuex way. That means you can only call the stuff that would be passed as context.
 
 For `getters`:
 - state

--- a/src/decorators/Action.ts
+++ b/src/decorators/Action.ts
@@ -14,8 +14,8 @@ export default function Action<T, R>(
   ) {
     if (config.store) {
       const targetModule = (target as any).constructor;
-      targetModule.$store = context;
-      return (target as any)[key].call(targetModule, payload);
+      targetModule._statics.$store = context;
+      return (target as any)[key].call(targetModule._statics, payload);
     } else {
       const thisObject = { $store: context };
       for (const key of Object.keys(context.state)) {

--- a/src/decorators/Action.ts
+++ b/src/decorators/Action.ts
@@ -1,10 +1,10 @@
 import { ActionContext, Action as VuexAction } from 'vuex';
 import { stores, initStore, getClassName, config } from './utils';
+import { VuexModuleTarget } from '../types';
 
-export default function Action<T, R>(
+export default function Action<T extends VuexModuleTarget<S, R>, S, R>(
   target: T,
-  key: string | symbol,
-  descriptor: TypedPropertyDescriptor<(...args: any[]) => R>
+  key: string | symbol
 ) {
   initStore(target);
 
@@ -12,25 +12,25 @@ export default function Action<T, R>(
     context: ActionContext<any, any>,
     payload: any
   ) {
-    const targetModule = (target as any).constructor;
+    const targetModule = target.constructor;
 
     if (config.store && targetModule._caller) {
       targetModule[`${targetModule._caller}statics`].$store = context;
-      return (target as any)[key].call(
+      return target[key as string].call(
         targetModule[`${targetModule._caller}statics`],
         payload
       );
     } else if (config.store && targetModule._statics) {
       targetModule._statics.$store = context;
-      return (target as any)[key].call(targetModule._statics, payload);
+      return target[key as string].call(targetModule._statics, payload);
     } else {
       const thisObject = { $store: context };
       for (const key of Object.keys(context.state)) {
         Object.assign(thisObject, { [key]: context.state[key] });
       }
-      return (target as any)[key].call(thisObject, payload);
+      return target[key as string].call(thisObject, payload);
     }
   };
 
-  stores[getClassName(target)].actions![key as string] = action;
+  stores[getClassName(target)]!.actions![key as string] = action;
 }

--- a/src/decorators/Action.ts
+++ b/src/decorators/Action.ts
@@ -12,8 +12,15 @@ export default function Action<T, R>(
     context: ActionContext<any, any>,
     payload: any
   ) {
-    if (config.store) {
-      const targetModule = (target as any).constructor;
+    const targetModule = (target as any).constructor;
+
+    if (config.store && targetModule._caller) {
+      targetModule[`${targetModule._caller}statics`].$store = context;
+      return (target as any)[key].call(
+        targetModule[`${targetModule._caller}statics`],
+        payload
+      );
+    } else if (config.store && targetModule._statics) {
       targetModule._statics.$store = context;
       return (target as any)[key].call(targetModule._statics, payload);
     } else {

--- a/src/decorators/Action.ts
+++ b/src/decorators/Action.ts
@@ -1,5 +1,5 @@
 import { ActionContext, Action as VuexAction } from 'vuex';
-import { stores, initStore, getClassName } from './utils';
+import { stores, initStore, getClassName, config } from './utils';
 
 export default function Action<T, R>(
   target: T,
@@ -12,9 +12,17 @@ export default function Action<T, R>(
     context: ActionContext<any, any>,
     payload: any
   ) {
-    const targetModule = (target as any).constructor;
-    targetModule.$store = context;
-    return (target as any)[key].call(targetModule, payload);
+    if (config.store) {
+      const targetModule = (target as any).constructor;
+      targetModule.$store = context;
+      return (target as any)[key].call(targetModule, payload);
+    } else {
+      const thisObject = { $store: context };
+      for (const key of Object.keys(context.state)) {
+        Object.assign(thisObject, { [key]: context.state[key] });
+      }
+      return (target as any)[key].call(thisObject, payload);
+    }
   };
 
   stores[getClassName(target)].actions![key as string] = action;

--- a/src/decorators/Action.ts
+++ b/src/decorators/Action.ts
@@ -12,11 +12,9 @@ export default function Action<T, R>(
     context: ActionContext<any, any>,
     payload: any
   ) {
-    const thisObject = { $store: context };
-    for (const key of Object.keys(context.state)) {
-      Object.assign(thisObject, { [key]: context.state[key] });
-    }
-    return (target as any)[key].call(thisObject, payload);
+    const targetModule = (target as any).constructor;
+    targetModule.$store = context;
+    return (target as any)[key].call(targetModule, payload);
   };
 
   stores[getClassName(target)].actions![key as string] = action;

--- a/src/decorators/ExportVuexStore.ts
+++ b/src/decorators/ExportVuexStore.ts
@@ -1,7 +1,16 @@
 import { stores, getClassName, AverModule } from './utils';
 
+function mapGetterFns<S, R>(store: AverModule<S, R>) {
+  store.getters = {
+    ...store.getters,
+    ...store._getterFns,
+  };
+}
+
 function nestStore(name: string) {
-  const store = stores[name];
+  const store = { ...stores[name] };
+
+  mapGetterFns(store);
 
   for (const { moduleName } of store.nested) {
     const nestedModule = stores[moduleName];

--- a/src/decorators/ExportVuexStore.ts
+++ b/src/decorators/ExportVuexStore.ts
@@ -26,12 +26,7 @@ function nestStore(name: string) {
   return store;
 }
 
-export default function ExportVuexStore<
-  S,
-  R,
-  T extends VuexModuleClass<S, R>,
-  N
->(
+export default function ExportVuexStore<S, R, T extends VuexModuleClass<S, R>>(
   target: T,
   exportAsReadyObject = false
 ): AverModule<S, R> | { [key: string]: AverModule<S, R> } {

--- a/src/decorators/ExportVuexStore.ts
+++ b/src/decorators/ExportVuexStore.ts
@@ -1,7 +1,7 @@
 import { stores, getClassName } from './utils';
 import { VuexModuleClass, AverModule } from '../types';
 
-function mapGetterFns<S, R, N>(store: AverModule<S, R, N>) {
+function mapGetterFns<S, R>(store: AverModule<S, R>) {
   store.getters = {
     ...store.getters,
     ...store._getterFns,
@@ -18,7 +18,7 @@ function nestStore(name: string) {
     if (stores[moduleName]) {
       const nestedModule = { ...stores[moduleName]! };
       mapGetterFns(nestedModule);
-      store.modules![moduleName] = nestedModule;
+      if (store.modules) store.modules[moduleName] = nestedModule;
       if (nestedModule.nested.length > 0) nestStore(moduleName);
     }
   }
@@ -34,7 +34,7 @@ export default function ExportVuexStore<
 >(
   target: T,
   exportAsReadyObject = false
-): AverModule<S, R, N> | { [key: string]: AverModule<S, R, N> } {
+): AverModule<S, R> | { [key: string]: AverModule<S, R> } {
   if (!target._statics && target._genStatic) target._genStatic();
 
   const name = getClassName(target);

--- a/src/decorators/ExportVuexStore.ts
+++ b/src/decorators/ExportVuexStore.ts
@@ -1,6 +1,6 @@
 import { stores, getClassName, AverModule } from './utils';
 
-function mapGetterFns<S, R>(store: AverModule<S, R>) {
+function mapGetterFns<S, R, N>(store: AverModule<S, R, N>) {
   store.getters = {
     ...store.getters,
     ...store._getterFns,
@@ -13,7 +13,8 @@ function nestStore(name: string) {
   mapGetterFns(store);
 
   for (const { moduleName } of store.nested) {
-    const nestedModule = stores[moduleName];
+    const nestedModule = { ...stores[moduleName] };
+    mapGetterFns(nestedModule);
     store.modules![moduleName] = nestedModule;
     if (nestedModule.nested.length > 0) nestStore(moduleName);
   }
@@ -21,10 +22,12 @@ function nestStore(name: string) {
   return store;
 }
 
-export default function ExportVuexStore<S, R, T>(
+export default function ExportVuexStore<S, R, T, N>(
   target: T,
   exportAsReadyObject = false
-): AverModule<S, R> | { [key: string]: AverModule<S, R> } {
+): AverModule<S, R, N> | { [key: string]: AverModule<S, R, N> } {
+  (target as any)._genStatic();
+
   const name = getClassName(target);
   const store = nestStore(name);
 

--- a/src/decorators/ExportVuexStore.ts
+++ b/src/decorators/ExportVuexStore.ts
@@ -26,7 +26,8 @@ export default function ExportVuexStore<S, R, T, N>(
   target: T,
   exportAsReadyObject = false
 ): AverModule<S, R, N> | { [key: string]: AverModule<S, R, N> } {
-  (target as any)._genStatic();
+  const targetModule = target as any;
+  if (!targetModule._statics) targetModule._genStatic();
 
   const name = getClassName(target);
   const store = nestStore(name);

--- a/src/decorators/Getter.ts
+++ b/src/decorators/Getter.ts
@@ -1,5 +1,6 @@
 import { Getter } from 'vuex';
-import { stores, initStore, getClassName, config } from './utils';
+import { stores, initStore, getClassName } from './utils';
+import { GetterFn } from './helpers';
 
 export default function Getter<T, R>(
   target: T,
@@ -17,36 +18,4 @@ export default function Getter<T, R>(
     targetModule,
     (target as any)[key]
   );
-}
-
-export function GetterFn<S, R>(targetModule: any, getterFn: () => {}) {
-  return (state: S, getters: any, rootState: R, rootGetters: any) => {
-    let output;
-    if (config.store && targetModule._caller) {
-      targetModule[`${targetModule._caller}staticGetters`].$store = {
-        state,
-        getters,
-        rootState,
-        rootGetters,
-      };
-      output = getterFn.call(
-        targetModule[`${targetModule._caller}staticGetters`]
-      );
-    } else if (config.store && targetModule._staticGetters) {
-      targetModule._staticGetters.$store = {
-        state,
-        getters,
-        rootState,
-        rootGetters,
-      };
-      output = getterFn.call(targetModule._staticGetters);
-    } else {
-      const thisObject = { $store: { state, getters, rootState, rootGetters } };
-      for (const key of Object.keys(state)) {
-        Object.assign(thisObject, { [key]: (state as any)[key] });
-      }
-      output = getterFn.call(thisObject);
-    }
-    return output;
-  };
 }

--- a/src/decorators/Getter.ts
+++ b/src/decorators/Getter.ts
@@ -11,14 +11,17 @@ export default function Getter<T, R>(
 
   if (!store._getterFns) store._getterFns = {};
 
-  store._getterFns[key as string] = <S, R>(
-    state: S,
-    getters: any,
-    rootState: R,
-    rootGetters: any
-  ) => {
+  const targetModule = (target as any).constructor;
+
+  store._getterFns[key as string] = GetterFn(
+    targetModule,
+    (target as any)[key]
+  );
+}
+
+export function GetterFn<S, R>(targetModule: any, getterFn: () => {}) {
+  return (state: S, getters: any, rootState: R, rootGetters: any) => {
     let output;
-    const targetModule = (target as any).constructor;
     if (config.store && targetModule._caller) {
       targetModule[`${targetModule._caller}staticGetters`].$store = {
         state,
@@ -26,7 +29,7 @@ export default function Getter<T, R>(
         rootState,
         rootGetters,
       };
-      output = (target as any)[key].call(
+      output = getterFn.call(
         targetModule[`${targetModule._caller}staticGetters`]
       );
     } else if (config.store && targetModule._staticGetters) {
@@ -36,13 +39,13 @@ export default function Getter<T, R>(
         rootState,
         rootGetters,
       };
-      output = (target as any)[key].call(targetModule._staticGetters);
+      output = getterFn.call(targetModule._staticGetters);
     } else {
       const thisObject = { $store: { state, getters, rootState, rootGetters } };
       for (const key of Object.keys(state)) {
         Object.assign(thisObject, { [key]: (state as any)[key] });
       }
-      output = (target as any)[key].call(thisObject);
+      output = getterFn.call(thisObject);
     }
     return output;
   };

--- a/src/decorators/Getter.ts
+++ b/src/decorators/Getter.ts
@@ -1,5 +1,5 @@
 import { Getter } from 'vuex';
-import { stores, initStore, getClassName } from './utils';
+import { stores, initStore, getClassName, config } from './utils';
 
 export default function Getter<T, R>(
   target: T,
@@ -17,14 +17,23 @@ export default function Getter<T, R>(
     rootState: R,
     rootGetters: any
   ) => {
-    const targetModule = (target as any).constructor;
-    targetModule._staticGetters.$store = {
-      state,
-      getters,
-      rootState,
-      rootGetters,
-    };
-    const output = (target as any)[key].call(targetModule._staticGetters);
+    let output;
+    if (config.store) {
+      const targetModule = (target as any).constructor;
+      targetModule._staticGetters.$store = {
+        state,
+        getters,
+        rootState,
+        rootGetters,
+      };
+      output = (target as any)[key].call(targetModule._staticGetters);
+    } else {
+      const thisObject = { $store: { state, getters, rootState, rootGetters } };
+      for (const key of Object.keys(state)) {
+        Object.assign(thisObject, { [key]: (state as any)[key] });
+      }
+      output = (target as any)[key].call(thisObject);
+    }
     return output;
   };
 }

--- a/src/decorators/Getter.ts
+++ b/src/decorators/Getter.ts
@@ -18,7 +18,12 @@ export default function Getter<T, R>(
     rootGetters: any
   ) => {
     const targetModule = (target as any).constructor;
-    targetModule.$store = { state, getters, rootState, rootGetters };
+    targetModule._staticGetters.$store = {
+      state,
+      getters,
+      rootState,
+      rootGetters,
+    };
     const output = (target as any)[key].call(targetModule._staticGetters);
     return output;
   };

--- a/src/decorators/Getter.ts
+++ b/src/decorators/Getter.ts
@@ -7,17 +7,19 @@ export default function Getter<T, R>(
   descriptor: TypedPropertyDescriptor<(...args: any[]) => R>
 ) {
   initStore(target);
-  stores[getClassName(target)].getters![key as string] = <S, R>(
+  const store = stores[getClassName(target)];
+
+  if (!store._getterFns) store._getterFns = {};
+
+  store._getterFns[key as string] = <S, R>(
     state: S,
     getters: any,
     rootState: R,
     rootGetters: any
   ) => {
-    const thisObject = { $store: { state, getters, rootState, rootGetters } };
-    for (const key of Object.keys(state)) {
-      Object.assign(thisObject, { [key]: (state as any)[key] });
-    }
-    const output = (target as any)[key].call(thisObject);
+    const targetModule = (target as any).constructor;
+    targetModule.$store = { state, getters, rootState, rootGetters };
+    const output = (target as any)[key].call(targetModule._staticGetters);
     return output;
   };
 }

--- a/src/decorators/Getter.ts
+++ b/src/decorators/Getter.ts
@@ -18,8 +18,18 @@ export default function Getter<T, R>(
     rootGetters: any
   ) => {
     let output;
-    if (config.store) {
-      const targetModule = (target as any).constructor;
+    const targetModule = (target as any).constructor;
+    if (config.store && targetModule._caller) {
+      targetModule[`${targetModule._caller}staticGetters`].$store = {
+        state,
+        getters,
+        rootState,
+        rootGetters,
+      };
+      output = (target as any)[key].call(
+        targetModule[`${targetModule._caller}staticGetters`]
+      );
+    } else if (config.store && targetModule._staticGetters) {
       targetModule._staticGetters.$store = {
         state,
         getters,

--- a/src/decorators/Getter.ts
+++ b/src/decorators/Getter.ts
@@ -1,21 +1,21 @@
 import { Getter } from 'vuex';
 import { stores, initStore, getClassName } from './utils';
 import { GetterFn } from './helpers';
+import { VuexModuleTarget } from '../types';
 
-export default function Getter<T, R>(
+export default function Getter<T extends VuexModuleTarget<S, R>, S, R>(
   target: T,
-  key: string | symbol,
-  descriptor: TypedPropertyDescriptor<(...args: any[]) => R>
+  key: string | symbol
 ) {
   initStore(target);
-  const store = stores[getClassName(target)];
+  const store = stores[getClassName(target)]!;
 
   if (!store._getterFns) store._getterFns = {};
 
-  const targetModule = (target as any).constructor;
+  const targetModule = target.constructor;
 
   store._getterFns[key as string] = GetterFn(
     targetModule,
-    (target as any)[key]
+    target[key as string]
   );
 }

--- a/src/decorators/HasGetter.ts
+++ b/src/decorators/HasGetter.ts
@@ -1,7 +1,13 @@
 import { stores, initStore, getClassName } from './utils';
+import { VuexModuleTarget } from '../types';
 
-export default function HasGetter<T>(target: T, key: string | symbol) {
+export default function HasGetter<
+  T extends VuexModuleTarget<S, R>,
+  S extends { [index: string]: any },
+  R
+>(target: T, key: string | symbol) {
   initStore(target);
-  stores[getClassName(target)].getters![key as string] = (state: any) =>
-    state[key];
+
+  stores[getClassName(target)]!.getters![key as string] = (state: S) =>
+    state[key as string];
 }

--- a/src/decorators/HasGetterAndMutation.ts
+++ b/src/decorators/HasGetterAndMutation.ts
@@ -1,13 +1,16 @@
 import Vue from 'vue';
 import { stores, initStore, getClassName } from './utils';
+import { VuexModuleTarget } from '../types';
 
-export default function HasGetterAndMutation<T>(
-  target: T,
-  key: string | symbol
-) {
+export default function HasGetterAndMutation<
+  T extends VuexModuleTarget<S, R>,
+  S,
+  R
+>(target: T, key: string | symbol) {
   initStore(target);
-  stores[getClassName(target)].getters![key as string] = (state) => state[key];
-  stores[getClassName(target)].mutations![key as string] = (state, val) => {
+
+  stores[getClassName(target)]!.getters![key as string] = (state) => state[key];
+  stores[getClassName(target)]!.mutations![key as string] = (state, val) => {
     Vue.set(state, key as string, val);
   };
 }

--- a/src/decorators/Mutation.ts
+++ b/src/decorators/Mutation.ts
@@ -1,15 +1,16 @@
 import { stores, initStore, getClassName } from './utils';
+import { VuexModuleTarget } from '../types';
 
-export default function Mutation<T, R>(
+export default function Mutation<T extends VuexModuleTarget<S, R>, S, R>(
   target: T,
-  key: string | symbol,
-  descriptor: TypedPropertyDescriptor<(...args: any[]) => R>
+  key: string | symbol
 ) {
   initStore(target);
-  stores[getClassName(target)].mutations![key as string] = <S, R>(
+
+  stores[getClassName(target)]!.mutations![key as string] = <S, R>(
     state: S,
     payload: R
   ) => {
-    (target as any)[key].call(state, payload);
+    target[key as string].call(state, payload);
   };
 }

--- a/src/decorators/Nested.ts
+++ b/src/decorators/Nested.ts
@@ -13,6 +13,7 @@ function Nested(value?: any) {
     stores[getClassName(target)].nested.push({
       prop: key.toString(),
       moduleName,
+      module: value || targetObj[key].constructor,
     });
   };
 }

--- a/src/decorators/StaticGenerators.ts
+++ b/src/decorators/StaticGenerators.ts
@@ -1,11 +1,6 @@
-import { config, AverModule, stores } from './utils';
+import { stores, config } from './utils';
 import { GetterTree, MutationTree, ActionTree } from 'vuex';
-
-export type ConstructorOf<C> = { new (...args: any[]): C };
-
-export interface PropertiesToDefine {
-  [key: string]: PropertyDescriptor & ThisType<any>;
-}
+import { AverModule, PropertiesToDefine, ConstructorOf } from '../types';
 
 /**
  * Generate static properties for nested modules
@@ -39,7 +34,7 @@ export function generateStaticNestedProperties<S, R, N>(
           writable: true,
         },
       };
-      const nestedModule = stores[moduleName];
+      const nestedModule = stores[moduleName]!;
 
       if (nestedModule.nested.length > 0) {
         generateStaticNestedProperties(

--- a/src/decorators/StaticGenerators.ts
+++ b/src/decorators/StaticGenerators.ts
@@ -41,6 +41,20 @@ export function generateStaticNestedProperties<S, R, N>(
       };
       const nestedModule = stores[moduleName];
 
+      if (nestedModule.nested.length > 0) {
+        generateStaticNestedProperties(
+          nestedModule,
+          nestedPropertiesToDefine,
+          constructPath(
+            parentPath || store.moduleName,
+            moduleName,
+            '',
+            nestedModule.namespaced
+          ),
+          constructPath(parentPath || store.moduleName, moduleName, '')
+        );
+      }
+
       // We need to pass the full path to states because they, no matter if namespace true or false, always need the full path.
       generateStaticStates(
         nestedModule,
@@ -66,20 +80,6 @@ export function generateStaticNestedProperties<S, R, N>(
         parentPath || store.moduleName
       );
 
-      if (nestedModule.nested.length > 0) {
-        generateStaticNestedProperties(
-          nestedModule,
-          nestedPropertiesToDefine,
-          constructPath(
-            parentPath || store.moduleName,
-            moduleName,
-            '',
-            nestedModule.namespaced
-          ),
-          constructPath(parentPath || store.moduleName, moduleName, '')
-        );
-      }
-
       Object.defineProperty(module, staticGettersPath, {
         value: Object.defineProperties(
           {
@@ -100,19 +100,14 @@ export function generateStaticNestedProperties<S, R, N>(
 
     propertiesToDefine[prop] = {
       get() {
-        (module as any)._caller = `_[${constructPath(
+        const path = `_[${constructPath(
           parentPath || store.moduleName,
           moduleName,
           ''
         )}]`;
 
-        return (module as any)[
-          `_[${constructPath(
-            parentPath || store.moduleName,
-            moduleName,
-            ''
-          )}]statics`
-        ];
+        (module as any)._caller = path;
+        return (module as any)[`${path}statics`];
       },
     };
   }

--- a/src/decorators/StaticGenerators.ts
+++ b/src/decorators/StaticGenerators.ts
@@ -1,6 +1,11 @@
 import { stores, config } from './utils';
 import { GetterTree, MutationTree, ActionTree } from 'vuex';
-import { AverModule, PropertiesToDefine, ConstructorOf } from '../types';
+import {
+  AverModule,
+  PropertiesToDefine,
+  ConstructorOf,
+  VuexModuleClass,
+} from '../types';
 
 /**
  * Generate static properties for nested modules
@@ -10,8 +15,8 @@ import { AverModule, PropertiesToDefine, ConstructorOf } from '../types';
  * @param parentPath The path of the parent module to help construct nested paths
  * @param fullPath The full path of the nesting
  */
-export function generateStaticNestedProperties<S, R, N>(
-  store: AverModule<S, R, N>,
+export function generateStaticNestedProperties<S, R>(
+  store: AverModule<S, R>,
   propertiesToDefine: PropertiesToDefine,
   parentPath?: string,
   fullPath?: string
@@ -28,7 +33,7 @@ export function generateStaticNestedProperties<S, R, N>(
       ''
     )}]statics`;
 
-    if (!(module as any)[staticGettersPath] && !(module as any)[staticsPath]) {
+    if (!module[staticGettersPath] && !module[staticsPath]) {
       const nestedPropertiesToDefine = {
         _caller: {
           writable: true,
@@ -95,14 +100,15 @@ export function generateStaticNestedProperties<S, R, N>(
 
     propertiesToDefine[prop] = {
       get() {
+        // Before we can return the nested module we want to call, we need to set the internal _caller prop to the current path.
         const path = `_[${constructPath(
           parentPath || store.moduleName,
           moduleName,
           ''
         )}]`;
 
-        (module as any)._caller = path;
-        return (module as any)[`${path}statics`];
+        module._caller = path;
+        return module[`${path}statics`];
       },
     };
   }
@@ -117,8 +123,8 @@ export function generateStaticNestedProperties<S, R, N>(
  * @param propertiesToDefine The object which gets defined on the constructor
  * @param parentModuleName The path of the parent module
  */
-export function generateStaticStates<S, R, N>(
-  store: AverModule<S, R, N>,
+export function generateStaticStates<S, R>(
+  store: AverModule<S, R>,
   propertiesToDefine: PropertiesToDefine,
   parentModuleName: string = ''
 ): PropertiesToDefine {
@@ -151,8 +157,8 @@ export function generateStaticStates<S, R, N>(
  * @param propertiesToDefine The object which gets defined on the constructor
  * @param parentModuleName The path of the parent module
  */
-export function generateStaticGetters<S, R, N>(
-  store: AverModule<S, R, N>,
+export function generateStaticGetters<S, R>(
+  store: AverModule<S, R>,
   propertiesToDefine: PropertiesToDefine,
   parentModuleName: string = ''
 ): PropertiesToDefine {
@@ -200,8 +206,8 @@ export function generateStaticGetters<S, R, N>(
  * @param propertiesToDefine The object which gets defined on the constructor
  * @param parentModuleName The path of the parent module
  */
-export function generateStaticMutations<S, R, N>(
-  store: AverModule<S, R, N>,
+export function generateStaticMutations<S, R>(
+  store: AverModule<S, R>,
   propertiesToDefine: PropertiesToDefine,
   parentModuleName: string = ''
 ): PropertiesToDefine {
@@ -251,8 +257,8 @@ export function generateStaticMutations<S, R, N>(
  * @param propertiesToDefine The object which gets defined on the constructor
  * @param parentModuleName The path of the parent module
  */
-export function generateStaticActions<S, R, N>(
-  store: AverModule<S, R, N>,
+export function generateStaticActions<S, R>(
+  store: AverModule<S, R>,
   propertiesToDefine: PropertiesToDefine,
   parentModuleName: string = ''
 ): PropertiesToDefine {

--- a/src/decorators/StaticGenerators.ts
+++ b/src/decorators/StaticGenerators.ts
@@ -34,7 +34,11 @@ export function generateStaticNestedProperties<S, R, N>(
     )}]statics`;
 
     if (!(module as any)[staticGettersPath] && !(module as any)[staticsPath]) {
-      const nestedPropertiesToDefine = {};
+      const nestedPropertiesToDefine = {
+        _caller: {
+          writable: true,
+        },
+      };
       const nestedModule = stores[moduleName];
 
       // We need to pass the full path to states because they, no matter if namespace true or false, always need the full path.
@@ -77,16 +81,31 @@ export function generateStaticNestedProperties<S, R, N>(
       }
 
       Object.defineProperty(module, staticGettersPath, {
-        value: Object.defineProperties({ $store: {} }, getters),
+        value: Object.defineProperties(
+          {
+            $store: {},
+          },
+          getters
+        ),
       });
       Object.defineProperty(module, staticsPath, {
-        value: Object.defineProperties({}, nestedPropertiesToDefine),
+        value: Object.defineProperties(
+          {
+            $store: {},
+          },
+          nestedPropertiesToDefine
+        ),
       });
-      Object.defineProperty(module, '$store', { writable: true });
     }
 
     propertiesToDefine[prop] = {
-      get: () => {
+      get() {
+        (module as any)._caller = `_[${constructPath(
+          parentPath || store.moduleName,
+          moduleName,
+          ''
+        )}]`;
+
         return (module as any)[
           `_[${constructPath(
             parentPath || store.moduleName,

--- a/src/decorators/StaticGenerators.ts
+++ b/src/decorators/StaticGenerators.ts
@@ -1,11 +1,6 @@
 import { stores, config } from './utils';
 import { GetterTree, MutationTree, ActionTree } from 'vuex';
-import {
-  AverModule,
-  PropertiesToDefine,
-  ConstructorOf,
-  VuexModuleClass,
-} from '../types';
+import { AverModule, PropertiesToDefine, ConstructorOf } from '../types';
 
 /**
  * Generate static properties for nested modules

--- a/src/decorators/VuexClass.ts
+++ b/src/decorators/VuexClass.ts
@@ -20,9 +20,7 @@ function generateVuexClass<S, R>(options: VuexClassOptions) {
     const store = stores[getClassName(constructor)]!;
 
     for (const obj of options.extend || []) {
-      const extendStore = ExportVuexStore<any, any, typeof constructor, any>(
-        obj
-      );
+      const extendStore = ExportVuexStore<any, any, typeof constructor>(obj);
       const oldState = store.state();
       const newState = extendStore.state();
       const stateFactory = () => Object.assign(oldState, newState);

--- a/src/decorators/VuexClass.ts
+++ b/src/decorators/VuexClass.ts
@@ -1,5 +1,5 @@
 import ExportVuexStore from './ExportVuexStore';
-import { stores, assignStates, getClassName } from './utils';
+import { stores, getClassName } from './utils';
 import { ActionContext } from 'vuex';
 import {
   generateStaticStates,
@@ -8,20 +8,16 @@ import {
   generateStaticActions,
   generateStaticNestedProperties,
 } from './StaticGenerators';
-
-interface VuexClassOptions {
-  persistent?: Array<string>;
-  extend?: Array<any>;
-  namespaced?: boolean;
-}
+import { VuexClassOptions, VuexModuleClass } from '../types';
+import { assignStates } from './helpers';
 
 function generateVuexClass<S, R>(options: VuexClassOptions) {
-  return <TFunction extends Function>(
+  return <TFunction extends VuexModuleClass<S, R>>(
     constructor: TFunction
   ): TFunction | void => {
     assignStates(constructor);
 
-    const store = stores[getClassName(constructor)];
+    const store = stores[getClassName(constructor)]!;
 
     for (const obj of options.extend || []) {
       const extendStore = ExportVuexStore<any, any, typeof constructor, any>(
@@ -99,14 +95,16 @@ export class VuexModule<S = ThisType<any>, R = any> {
   $store!: ActionContext<S, R>;
 }
 
-export function VuexClass(module: Function & VuexClassOptions): void;
+export function VuexClass<S, R>(
+  module: VuexModuleClass<S, R> & VuexClassOptions
+): void;
 export function VuexClass(options: VuexClassOptions): ClassDecorator;
 
-export function VuexClass(
-  options: VuexClassOptions | (Function & VuexClassOptions)
+export function VuexClass<S, R>(
+  options: VuexClassOptions | (VuexModuleClass<S, R> & VuexClassOptions)
 ) {
   if (typeof (options as any) === 'function') {
-    generateVuexClass({})(options as Function & VuexClassOptions);
+    generateVuexClass({})(options as VuexModuleClass<S, R> & VuexClassOptions);
   } else {
     return generateVuexClass(options);
   }

--- a/src/decorators/VuexClass.ts
+++ b/src/decorators/VuexClass.ts
@@ -50,6 +50,8 @@ function generateVuexClass<S, R>(options: VuexClassOptions) {
      */
     Object.defineProperty(constructor, '_genStatic', {
       value: () => {
+        if ((constructor as any)._statics) return;
+
         const nestedPropertiesToDefine = {};
         const propertiesToDefine = {};
 
@@ -79,10 +81,16 @@ function generateVuexClass<S, R>(options: VuexClassOptions) {
             getters
           ),
         });
-        Object.defineProperty(constructor, '$store', { writable: true });
-        Object.defineProperties(constructor, {
-          ...nestedPropertiesToDefine,
-          ...propertiesToDefine,
+        Object.defineProperty(constructor, '_statics', {
+          value: Object.defineProperties(
+            {
+              $store: {},
+            },
+            {
+              ...nestedPropertiesToDefine,
+              ...propertiesToDefine,
+            }
+          ),
         });
       },
     });

--- a/src/decorators/VuexClass.ts
+++ b/src/decorators/VuexClass.ts
@@ -23,7 +23,7 @@ function generateVuexClass<S, R>(options: VuexClassOptions) {
 
     const store = stores[getClassName(constructor)];
 
-    for (const obj of options?.extend || []) {
+    for (const obj of options.extend || []) {
       const extendStore = ExportVuexStore<any, any, typeof constructor, any>(
         obj
       );
@@ -36,10 +36,10 @@ function generateVuexClass<S, R>(options: VuexClassOptions) {
       Object.assign(store.mutations, extendStore.mutations);
     }
 
-    if (options?.persistent) store.persistent = options.persistent;
+    if (options.persistent) store.persistent = options.persistent;
     else store.persistent = false;
 
-    if (typeof options?.namespaced !== 'undefined') {
+    if (typeof options.namespaced !== 'undefined') {
       store.namespaced = options.namespaced;
     }
 
@@ -52,10 +52,9 @@ function generateVuexClass<S, R>(options: VuexClassOptions) {
       value: () => {
         if ((constructor as any)._statics) return;
 
-        const nestedPropertiesToDefine = {};
         const propertiesToDefine = {};
 
-        generateStaticNestedProperties(store, nestedPropertiesToDefine);
+        generateStaticNestedProperties(store, propertiesToDefine);
         generateStaticStates(store, propertiesToDefine);
         generateStaticGetters(store, propertiesToDefine);
 
@@ -86,10 +85,7 @@ function generateVuexClass<S, R>(options: VuexClassOptions) {
             {
               $store: {},
             },
-            {
-              ...nestedPropertiesToDefine,
-              ...propertiesToDefine,
-            }
+            propertiesToDefine
           ),
         });
       },

--- a/src/decorators/helpers.ts
+++ b/src/decorators/helpers.ts
@@ -1,0 +1,33 @@
+import { config } from './utils';
+
+export function GetterFn<S, R>(targetModule: any, getterFn: () => void) {
+  return (state: S, getters: any, rootState: R, rootGetters: any) => {
+    let output;
+    if (config.store && targetModule._caller) {
+      targetModule[`${targetModule._caller}staticGetters`].$store = {
+        state,
+        getters,
+        rootState,
+        rootGetters,
+      };
+      output = getterFn.call(
+        targetModule[`${targetModule._caller}staticGetters`]
+      );
+    } else if (config.store && targetModule._staticGetters) {
+      targetModule._staticGetters.$store = {
+        state,
+        getters,
+        rootState,
+        rootGetters,
+      };
+      output = getterFn.call(targetModule._staticGetters);
+    } else {
+      const thisObject = { $store: { state, getters, rootState, rootGetters } };
+      for (const key of Object.keys(state)) {
+        Object.assign(thisObject, { [key]: (state as any)[key] });
+      }
+      output = getterFn.call(thisObject);
+    }
+    return output;
+  };
+}

--- a/src/decorators/helpers.ts
+++ b/src/decorators/helpers.ts
@@ -1,6 +1,11 @@
-import { config } from './utils';
+import { config, initStore, getClassName, stores, getStates } from './utils';
+import { VuexModuleClass, NewableVuexModuleClass } from '../types';
+import { GetterTree, MutationTree } from 'vuex';
 
-export function GetterFn<S, R>(targetModule: any, getterFn: () => void) {
+export function GetterFn<S, R>(
+  targetModule: VuexModuleClass<S, R>,
+  getterFn: () => void
+) {
   return (state: S, getters: any, rootState: R, rootGetters: any) => {
     let output;
     if (config.store && targetModule._caller) {
@@ -30,4 +35,50 @@ export function GetterFn<S, R>(targetModule: any, getterFn: () => void) {
     }
     return output;
   };
+}
+
+export function assignStates<S, R>(Obj: VuexModuleClass<S, R>) {
+  const target = new (Obj as NewableVuexModuleClass<S, R>)();
+  let props = Object.getOwnPropertyNames(target);
+  if (typeof target.moduleName === 'undefined') {
+    console.error(
+      `You need to define the 'moduleName' class variable inside '${target.constructor.name}'! Otherwise it won't be added to the Vuex Store!`
+    );
+  }
+
+  initStore(target);
+
+  /**
+   * We need to remove all props which have a moduleName and therefore are instances of a nested module.
+   * If we dont do that, every nested prop would be also declared as state and vuex throws a warning.
+   */
+  props = props.filter((prop) => !target[prop]?.moduleName);
+  const store = stores[getClassName(target)]!;
+
+  store.moduleName = target.moduleName;
+  props.splice(props.indexOf('moduleName'), 1);
+
+  const stateFactory = () => getStates(target, props);
+  store.state = stateFactory;
+
+  const proto = Object.getPrototypeOf(target);
+  const functions = Object.getOwnPropertyNames(proto);
+
+  const getters = {} as GetterTree<S, any>;
+  const mutations = {} as MutationTree<S>;
+
+  for (const func of functions) {
+    const descriptor = Object.getOwnPropertyDescriptor(proto, func);
+    if (descriptor && descriptor.get) {
+      getters[func] = GetterFn(Obj, descriptor.get);
+    }
+    if (descriptor && descriptor.set) {
+      mutations[func] = (state: S, payload: any) => {
+        (descriptor.set as Function).call(state, payload);
+      };
+    }
+  }
+
+  Object.assign(store.getters, getters);
+  Object.assign(store.mutations, mutations);
 }

--- a/src/decorators/utils.ts
+++ b/src/decorators/utils.ts
@@ -63,8 +63,27 @@ export function assignStates<S>(Obj: any) {
         rootState: any,
         rootGetters: GetterTree<any, any>
       ) => {
-        Obj.$store = { state, getters, rootState, rootGetters };
-        const output = (descriptor.get as Function).call(Obj._staticGetters);
+        let output;
+        if (config.store) {
+          const targetModule = Obj;
+          targetModule._staticGetters.$store = {
+            state,
+            getters,
+            rootState,
+            rootGetters,
+          };
+          output = (descriptor.get as Function).call(
+            targetModule._staticGetters
+          );
+        } else {
+          const thisObject = {
+            $store: { state, getters, rootState, rootGetters },
+          };
+          for (const key of Object.keys(state)) {
+            Object.assign(thisObject, { [key]: (state as any)[key] });
+          }
+          output = (descriptor.get as Function).call(thisObject);
+        }
         return output;
       };
     }

--- a/src/decorators/utils.ts
+++ b/src/decorators/utils.ts
@@ -1,5 +1,5 @@
 import { Store as VuexStore, Module, GetterTree, MutationTree } from 'vuex';
-import { GetterFn } from './Getter';
+import { GetterFn } from './helpers';
 
 interface NestedModule<N> {
   prop: string;

--- a/src/decorators/utils.ts
+++ b/src/decorators/utils.ts
@@ -1,19 +1,20 @@
 import { Store as VuexStore, Module, GetterTree, MutationTree } from 'vuex';
 
-interface NestedModule {
+interface NestedModule<N> {
   prop: string;
   moduleName: string;
+  module: N;
 }
 
-export interface AverModule<S, R> extends Module<S, R> {
+export interface AverModule<S, R, N> extends Module<S, R> {
   moduleName?: string;
   persistent?: string[] | boolean;
-  nested: NestedModule[];
+  nested: NestedModule<N>[];
   _getterFns?: GetterTree<S, R>;
 }
 
-interface Store<S, R> {
-  [key: string]: AverModule<S, R>;
+interface Store<S, R, N> {
+  [key: string]: AverModule<S, R, N>;
 }
 
 interface Config<S> {
@@ -22,7 +23,7 @@ interface Config<S> {
 
 export const config: Config<any> = {};
 
-export const stores: Store<any, any> = {};
+export const stores: Store<any, any, any> = {};
 
 export function assignStates<S>(Obj: any) {
   const target = new Obj();

--- a/src/decorators/utils.ts
+++ b/src/decorators/utils.ts
@@ -9,6 +9,7 @@ export interface AverModule<S, R> extends Module<S, R> {
   moduleName?: string;
   persistent?: string[] | boolean;
   nested: NestedModule[];
+  _getterFns?: GetterTree<S, R>;
 }
 
 interface Store<S, R> {
@@ -61,15 +62,8 @@ export function assignStates<S>(Obj: any) {
         rootState: any,
         rootGetters: GetterTree<any, any>
       ) => {
-        const thisObject = {
-          $store: { state, getters, rootState, rootGetters },
-        };
-        for (const key of Object.keys(state)) {
-          Object.defineProperty(thisObject, key, {
-            get: () => (state as any)[key],
-          });
-        }
-        const output = (descriptor.get as Function).call(thisObject);
+        Obj.$store = { state, getters, rootState, rootGetters };
+        const output = (descriptor.get as Function).call(Obj._staticGetters);
         return output;
       };
     }

--- a/src/decorators/utils.ts
+++ b/src/decorators/utils.ts
@@ -1,86 +1,23 @@
-import { Store as VuexStore, Module, GetterTree, MutationTree } from 'vuex';
-import { GetterFn } from './helpers';
-
-interface NestedModule<N> {
-  prop: string;
-  moduleName: string;
-  module: N;
-}
-
-export interface AverModule<S, R, N> extends Module<S, R> {
-  moduleName?: string;
-  persistent?: string[] | boolean;
-  nested: NestedModule<N>[];
-  _getterFns?: GetterTree<S, R>;
-}
-
-interface Store<S, R, N> {
-  [key: string]: AverModule<S, R, N>;
-}
-
-interface Config<S> {
-  store?: VuexStore<S>;
-}
+import { Config, Store, VuexModuleTarget } from '../types';
 
 export const config: Config<any> = {};
 
 export const stores: Store<any, any, any> = {};
 
-export function assignStates<S>(Obj: any) {
-  const target = new Obj();
-  let props = Object.getOwnPropertyNames(target);
-  if (typeof target.moduleName === 'undefined') {
-    console.error(
-      `You need to define the 'moduleName' class variable inside '${target.constructor.name}'! Otherwise it won't be added to the Vuex Store!`
-    );
-  }
-
-  initStore(target);
-
-  /**
-   * We need to remove all props which have a moduleName and therefore are instances of a nested module.
-   * If we dont do that, every nested prop would be also declared as state and vuex throws a warning.
-   */
-  props = props.filter((prop) => !target[prop]?.moduleName);
-
-  stores[getClassName(target)].moduleName = target.moduleName;
-  props.splice(props.indexOf('moduleName'), 1);
-
-  const stateFactory = () => getStates(target, props);
-  stores[getClassName(target)].state = stateFactory;
-
-  const proto = Object.getPrototypeOf(target);
-  const functions = Object.getOwnPropertyNames(proto);
-
-  const getters = {} as GetterTree<S, any>;
-  const mutations = {} as MutationTree<S>;
-
-  for (const func of functions) {
-    const descriptor = Object.getOwnPropertyDescriptor(proto, func);
-    if (descriptor && descriptor.get) {
-      getters[func] = GetterFn(Obj, descriptor.get);
-    }
-    if (descriptor && descriptor.set) {
-      mutations[func] = (state: S, payload: any) => {
-        (descriptor.set as Function).call(state, payload);
-      };
-    }
-  }
-
-  Object.assign(stores[getClassName(target)].getters, getters);
-  Object.assign(stores[getClassName(target)].mutations, mutations);
-}
-
-export function getStates<T>(target: T, props: string[]) {
+export function getStates<T extends VuexModuleTarget<S, R>, S, R>(
+  target: T,
+  props: string[]
+) {
   const s: { [key: string]: any } = {};
   for (const prop of props) {
-    s[prop] = (target as any)[prop];
+    s[prop] = target[prop];
   }
   return s;
 }
 
-export function initStore<T>(target: T): void {
-  // tslint:disable-next-line: strict-type-predicates
+export function initStore<T extends VuexModuleTarget<S, R>, S, R>(
+  target: T
+): void {
   if (typeof stores[getClassName(target)] === 'undefined') {
     stores[getClassName(target)] = {
       namespaced: true,

--- a/src/decorators/utils.ts
+++ b/src/decorators/utils.ts
@@ -1,4 +1,5 @@
 import { Store as VuexStore, Module, GetterTree, MutationTree } from 'vuex';
+import { GetterFn } from './Getter';
 
 interface NestedModule<N> {
   prop: string;
@@ -57,35 +58,7 @@ export function assignStates<S>(Obj: any) {
   for (const func of functions) {
     const descriptor = Object.getOwnPropertyDescriptor(proto, func);
     if (descriptor && descriptor.get) {
-      getters[func] = (
-        state: S,
-        getters: GetterTree<S, any>,
-        rootState: any,
-        rootGetters: GetterTree<any, any>
-      ) => {
-        let output;
-        if (config.store) {
-          const targetModule = Obj;
-          targetModule._staticGetters.$store = {
-            state,
-            getters,
-            rootState,
-            rootGetters,
-          };
-          output = (descriptor.get as Function).call(
-            targetModule._staticGetters
-          );
-        } else {
-          const thisObject = {
-            $store: { state, getters, rootState, rootGetters },
-          };
-          for (const key of Object.keys(state)) {
-            Object.assign(thisObject, { [key]: (state as any)[key] });
-          }
-          output = (descriptor.get as Function).call(thisObject);
-        }
-        return output;
-      };
+      getters[func] = GetterFn(Obj, descriptor.get);
     }
     if (descriptor && descriptor.set) {
       mutations[func] = (state: S, payload: any) => {

--- a/src/decorators/utils.ts
+++ b/src/decorators/utils.ts
@@ -2,7 +2,7 @@ import { Config, Store, VuexModuleTarget } from '../types';
 
 export const config: Config<any> = {};
 
-export const stores: Store<any, any, any> = {};
+export const stores: Store<any, any> = {};
 
 export function getStates<T extends VuexModuleTarget<S, R>, S, R>(
   target: T,

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,21 +41,21 @@ export interface PropertiesToDefine {
   [key: string]: PropertyDescriptor & ThisType<any>;
 }
 
-export interface NestedModule<N> {
+export interface NestedModule<S, R> {
   prop: string;
   moduleName: string;
-  module: N;
+  module: VuexModuleClass<S, R>;
 }
 
-export interface AverModule<S, R, N> extends Module<S, R> {
+export interface AverModule<S, R> extends Module<S, R> {
   moduleName?: string;
   persistent?: string[] | boolean;
-  nested: NestedModule<N>[];
+  nested: NestedModule<S, R>[];
   _getterFns?: GetterTree<S, R>;
 }
 
-export interface Store<S, R, N> {
-  [key: string]: AverModule<S, R, N> | undefined;
+export interface Store<S, R> {
+  [key: string]: AverModule<S, R> | undefined;
 }
 
 export interface Config<S> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,8 +26,8 @@ export interface VuexModuleClass<S, R> extends Function {
   };
 }
 
-export interface NewableVuexModuleClass<S, R> extends VuexModuleClass<S, R> {
-  new (): this;
+export interface NewableVuexModuleClass<S, R> {
+  new (): VuexModuleClass<S, R>;
 }
 
 export interface VuexModuleTarget<S = any, R = any> extends Object {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,63 @@
+import { Store as VuexStore, ActionContext, Module, GetterTree } from 'vuex';
+
+export interface VuexClassOptions {
+  persistent?: Array<string>;
+  extend?: Array<any>;
+  namespaced?: boolean;
+}
+
+export interface VuexModuleClass<S, R> extends Function {
+  [index: string]: VuexModuleClass<S, R> | any;
+  moduleName?: string;
+  _genStatic?: () => void;
+  _caller?: string;
+  _staticGetters?: {
+    [index: string]: any;
+    $store: {
+      state: S;
+      getters: any;
+      rootState: R;
+      rootGetters: any;
+    };
+  };
+  _statics?: {
+    [index: string]: any;
+    $store: ActionContext<S, R>;
+  };
+}
+
+export interface NewableVuexModuleClass<S, R> extends VuexModuleClass<S, R> {
+  new (): this;
+}
+
+export interface VuexModuleTarget<S = any, R = any> extends Object {
+  [index: string]: any;
+  constructor: VuexModuleClass<S, R> & Function;
+}
+
+export type ConstructorOf<C> = { new (...args: any[]): C };
+
+export interface PropertiesToDefine {
+  [key: string]: PropertyDescriptor & ThisType<any>;
+}
+
+export interface NestedModule<N> {
+  prop: string;
+  moduleName: string;
+  module: N;
+}
+
+export interface AverModule<S, R, N> extends Module<S, R> {
+  moduleName?: string;
+  persistent?: string[] | boolean;
+  nested: NestedModule<N>[];
+  _getterFns?: GetterTree<S, R>;
+}
+
+export interface Store<S, R, N> {
+  [key: string]: AverModule<S, R, N> | undefined;
+}
+
+export interface Config<S> {
+  store?: VuexStore<S>;
+}

--- a/test/Action.test.ts
+++ b/test/Action.test.ts
@@ -19,10 +19,25 @@ function storeWrapper(doNotConfigStore = false) {
   @VuexClass({
     namespaced: true,
   })
+  class NestedAgainStore extends VuexModule {
+    private moduleName = 'nestedAgainStore';
+
+    nestedState = 'nested again';
+
+    @Getter getNestedState() {
+      return this.nestedState;
+    }
+  }
+
+  @VuexClass({
+    namespaced: true,
+  })
   class NestedStore extends VuexModule {
     private moduleName = 'nestedStore';
 
     nestedState = 'nested';
+
+    @Nested() nestedAgain = new NestedAgainStore();
 
     @Getter getNestedState() {
       return this.nestedState;

--- a/test/Action.test.ts
+++ b/test/Action.test.ts
@@ -42,6 +42,10 @@ function storeWrapper(doNotConfigStore = false) {
     @Getter getNestedState() {
       return this.nestedState;
     }
+
+    @Action async nestedAction() {
+      return this.nestedState;
+    }
   }
 
   @VuexClass
@@ -68,7 +72,7 @@ function storeWrapper(doNotConfigStore = false) {
 
     @Action async testMutationThisContext() {
       this.testState = 'testModified';
-      return this.nested.getNestedState();
+      return this.nested.nestedAction();
     }
 
     @Action async modifyState() {

--- a/test/Action.test.ts
+++ b/test/Action.test.ts
@@ -11,61 +11,72 @@ import {
   Nested,
 } from '../src';
 import { VuexModule } from '../src/decorators/VuexClass';
+import { stores } from '../src/decorators/utils';
 
 Vue.use(Vuex);
 
-@VuexClass({
-  namespaced: true,
-})
-class NestedStore extends VuexModule {
-  private moduleName = 'nestedStore';
+function storeWrapper(doNotConfigStore = false) {
+  @VuexClass({
+    namespaced: true,
+  })
+  class NestedStore extends VuexModule {
+    private moduleName = 'nestedStore';
 
-  nestedState = 'nested';
+    nestedState = 'nested';
 
-  @Getter getNestedState() {
-    return this.nestedState;
+    @Getter getNestedState() {
+      return this.nestedState;
+    }
   }
+
+  @VuexClass
+  class TestModule extends VuexModule {
+    private moduleName = 'testModule';
+
+    plainTestState = 'servus';
+    @HasGetterAndMutation testState = 'test';
+
+    @Nested() nested = new NestedStore();
+
+    @Getter getTestState() {
+      return this.testState;
+    }
+
+    @Mutation setTestState(val: string) {
+      this.testState = val;
+    }
+
+    @Action async testMutation$store() {
+      (this.$store.state as any).testState = 'testModified';
+      return this.$store.rootGetters['testModule/nestedStore/getNestedState'];
+    }
+
+    @Action async testMutationThisContext() {
+      this.testState = 'testModified';
+      return this.nested.getNestedState();
+    }
+  }
+
+  const tm = ExportVuexStore(TestModule);
+
+  const store = new Vuex.Store({
+    modules: {
+      [tm.moduleName as string]: tm,
+    },
+  });
+
+  if (!doNotConfigStore) config.store = store;
+
+  return { tm, store };
 }
 
-@VuexClass
-class TestModule extends VuexModule {
-  private moduleName = 'testModule';
-
-  plainTestState = 'servus';
-  @HasGetterAndMutation testState = 'test';
-
-  @Nested() nested = new NestedStore();
-
-  @Getter getTestState() {
-    return this.testState;
-  }
-
-  @Mutation setTestState(val: string) {
-    this.testState = val;
-  }
-
-  @Action async testMutation$store() {
-    (this.$store.state as any).testState = 'testModified';
-    return this.$store.rootGetters['testModule/nestedStore/getNestedState'];
-  }
-
-  @Action async testMutationThisContext() {
-    this.testState = 'testModified';
-    return this.nested.getNestedState();
-  }
-}
-
-const tm = ExportVuexStore(TestModule);
-
-const store = new Vuex.Store({
-  modules: {
-    [tm.moduleName as string]: tm,
-  },
+beforeEach(() => {
+  for (const store of Object.keys(stores)) delete stores[store];
+  config.store = undefined;
 });
 
-config.store = store;
-
 test('check if action exists and is a function', () => {
+  const { tm } = storeWrapper();
   expect(tm.actions).toEqual({
     testMutationThisContext: expect.any(Function),
     testMutation$store: expect.any(Function),
@@ -73,12 +84,21 @@ test('check if action exists and is a function', () => {
 });
 
 test("dispatching the 'testMutationThisContext' action mutates the test state to 'testModified' and return state from nested module", async () => {
+  const { store } = storeWrapper();
   const value = await store.dispatch('testModule/testMutationThisContext');
   expect(value).toBe('nested');
   expect((store.state as any).testModule.testState).toBe('testModified');
 });
 
 test("dispatching the 'testMutation$store' action mutates the test state to 'testModified' and return state from nested module", async () => {
+  const { store } = storeWrapper();
+  const value = await store.dispatch('testModule/testMutation$store');
+  expect(value).toBe('nested');
+  expect((store.state as any).testModule.testState).toBe('testModified');
+});
+
+test('actions should work without the store passed to config', async () => {
+  const { store } = storeWrapper(true);
   const value = await store.dispatch('testModule/testMutation$store');
   expect(value).toBe('nested');
   expect((store.state as any).testModule.testState).toBe('testModified');

--- a/test/ExportVuexStore.test.ts
+++ b/test/ExportVuexStore.test.ts
@@ -11,9 +11,9 @@ function storeWrapper(exportAsReadyObject = false) {
   return tm;
 }
 
-test('check if object is a valid vuex object', <S = any, R = any, N = any>() => {
+test('check if object is a valid vuex object', <S = any, R = any>() => {
   const tm = storeWrapper();
-  const obj: AverModule<S, R, N> = {
+  const obj: AverModule<S, R> = {
     namespaced: true,
     nested: [],
     getters: {},

--- a/test/ExportVuexStore.test.ts
+++ b/test/ExportVuexStore.test.ts
@@ -1,5 +1,5 @@
-import { VuexClass, ExportVuexStore } from '../src';
-import { AverModule } from '../src/decorators/utils';
+import { VuexClass, ExportVuexStore, Nested } from '../src';
+import { AverModule } from '../src/types';
 
 function storeWrapper(exportAsReadyObject = false) {
   @VuexClass
@@ -35,4 +35,10 @@ test('tm should be plain object with moduleName prop', () => {
 test('tm object should have a key like the moduleName', () => {
   const tm = storeWrapper(true);
   expect(Object.keys(tm)).toEqual(['testModule']);
+});
+
+test('should return empty object when passing wrong object', () => {
+  class Test {}
+  const tm = ExportVuexStore(Test);
+  expect(tm).toEqual({ nested: [] });
 });

--- a/test/ExportVuexStore.test.ts
+++ b/test/ExportVuexStore.test.ts
@@ -1,14 +1,19 @@
 import { VuexClass, ExportVuexStore } from '../src';
 import { AverModule } from '../src/decorators/utils';
 
-@VuexClass
-class TestModule {
-  moduleName = 'testModule';
+function storeWrapper(exportAsReadyObject = false) {
+  @VuexClass
+  class TestModule {
+    moduleName = 'testModule';
+  }
+
+  const tm = ExportVuexStore(TestModule, exportAsReadyObject);
+  return tm;
 }
 
-test('check if object is a valid vuex object', <S = any, R = any>() => {
-  const tm = ExportVuexStore(TestModule);
-  const obj: AverModule<S, R> = {
+test('check if object is a valid vuex object', <S = any, R = any, N = any>() => {
+  const tm = storeWrapper();
+  const obj: AverModule<S, R, N> = {
     namespaced: true,
     nested: [],
     getters: {},
@@ -23,11 +28,11 @@ test('check if object is a valid vuex object', <S = any, R = any>() => {
 });
 
 test('tm should be plain object with moduleName prop', () => {
-  const tm = ExportVuexStore(TestModule);
+  const tm = storeWrapper();
   expect(tm.moduleName).toBe('testModule');
 });
 
 test('tm object should have a key like the moduleName', () => {
-  const tm = ExportVuexStore(TestModule, true);
+  const tm = storeWrapper(true);
   expect(Object.keys(tm)).toEqual(['testModule']);
 });

--- a/test/Getter.test.ts
+++ b/test/Getter.test.ts
@@ -10,6 +10,9 @@ function storeWrapper(doNotConfigStore = false) {
   class TestModule {
     moduleName = 'testModule';
     test = 'test';
+    get getterTest() {
+      return this.test;
+    }
     @Getter getTest() {
       return this.test;
     }
@@ -40,6 +43,7 @@ beforeEach(() => {
 test('check if getter exists and is a function', () => {
   const { tm } = storeWrapper();
   expect(tm.getters).toEqual({
+    getterTest: expect.any(Function),
     getTest: expect.any(Function),
     modifyState: expect.any(Function),
   });
@@ -48,6 +52,7 @@ test('check if getter exists and is a function', () => {
 test('the getter is present in the vuex store object', () => {
   const { store } = storeWrapper();
   expect(Object.keys(store.getters)).toEqual([
+    'testModule/getterTest',
     'testModule/getTest',
     'testModule/modifyState',
   ]);
@@ -56,7 +61,9 @@ test('the getter is present in the vuex store object', () => {
 test("calling getter returns the value from the 'test' variable", () => {
   const { store } = storeWrapper();
   const testVariable = store.getters['testModule/getTest'];
+  const getterTestVariable = store.getters['testModule/getterTest'];
   expect(testVariable).toBe('test');
+  expect(getterTestVariable).toBe('test');
 });
 
 test('getters should work without the store passed to config', () => {

--- a/test/Getter.test.ts
+++ b/test/Getter.test.ts
@@ -1,37 +1,56 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 import { VuexClass, ExportVuexStore, Getter, config } from '../src';
+import { stores } from '../src/decorators/utils';
 
 Vue.use(Vuex);
 
-@VuexClass
-class TestModule {
-  moduleName = 'testModule';
-  test = 'test';
-  @Getter getTest() {
-    return this.test;
+function storeWrapper(doNotConfigStore = false) {
+  @VuexClass
+  class TestModule {
+    moduleName = 'testModule';
+    test = 'test';
+    @Getter getTest() {
+      return this.test;
+    }
   }
+
+  const tm = ExportVuexStore(TestModule);
+
+  const store = new Vuex.Store({
+    modules: {
+      [tm.moduleName as string]: tm,
+    },
+  });
+
+  if (!doNotConfigStore) config.store = store;
+
+  return { tm, store };
 }
 
-const tm = ExportVuexStore(TestModule);
-
-const store = new Vuex.Store({
-  modules: {
-    [tm.moduleName as string]: tm,
-  },
+beforeEach(() => {
+  for (const store of Object.keys(stores)) delete stores[store];
+  config.store = undefined;
 });
 
-config.store = store;
-
 test('check if getter exists and is a function', () => {
+  const { tm } = storeWrapper();
   expect(tm.getters).toEqual({ getTest: expect.any(Function) });
 });
 
 test('the getter is present in the vuex store object', () => {
+  const { store } = storeWrapper();
   expect(Object.keys(store.getters)).toEqual(['testModule/getTest']);
 });
 
 test("calling getter returns the value from the 'test' variable", () => {
+  const { store } = storeWrapper();
+  const testVariable = store.getters['testModule/getTest'];
+  expect(testVariable).toBe('test');
+});
+
+test('getters should work without the store passed to config', () => {
+  const { store } = storeWrapper(true);
   const testVariable = store.getters['testModule/getTest'];
   expect(testVariable).toBe('test');
 });

--- a/test/Getter.test.ts
+++ b/test/Getter.test.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
-import { VuexClass, ExportVuexStore, Getter } from '../src';
+import { VuexClass, ExportVuexStore, Getter, config } from '../src';
 
 Vue.use(Vuex);
 
@@ -20,6 +20,8 @@ const store = new Vuex.Store({
     [tm.moduleName as string]: tm,
   },
 });
+
+config.store = store;
 
 test('check if getter exists and is a function', () => {
   expect(tm.getters).toEqual({ getTest: expect.any(Function) });

--- a/test/Mutation.test.ts
+++ b/test/Mutation.test.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
-import { VuexClass, ExportVuexStore, Getter, Mutation } from '../src';
+import { VuexClass, ExportVuexStore, Getter, Mutation, config } from '../src';
 
 Vue.use(Vuex);
 
@@ -25,6 +25,8 @@ const store = new Vuex.Store({
     [tm.moduleName as string]: tm,
   },
 });
+
+config.store = store;
 
 test('check if mutation exists and is a function', () => {
   expect(tm.mutations).toEqual({ setTest: expect.any(Function) });

--- a/test/StaticGenerator.test.ts
+++ b/test/StaticGenerator.test.ts
@@ -188,6 +188,11 @@ test('should generate static getters correctly', () => {
   expect(module.testCharCount).toBe(4);
   expect(propertiesToDefine.testCharCountTimes2.get!()()).toBe(8);
   expect(module.testCharCountTimes2()).toBe(8);
+
+  delete config.store;
+
+  expect(propertiesToDefine.testCharCount.get!()).toBeUndefined();
+  expect(propertiesToDefine.testCharCountTimes2.get!()()).toBeUndefined();
 });
 
 test('should generate static mutations correctly', () => {
@@ -226,6 +231,16 @@ test('should generate get and set for properties with HasGetterAndMutation', () 
   expect(propertiesToDefine.test.get!()).toBe('test2');
   expect(store.getters['testModule/test']).toBe('test2');
   expect(module.test).toBe('test2');
+
+  delete config.store;
+
+  expect(propertiesToDefine.test.get!()).toBeUndefined();
+  /**
+   * this should still be 'test2' because the fallback to $store should be used
+   * when config.store is not available
+   */
+  expect(store.getters['testModule/test']).toBe('test2');
+  expect(module.test).toBeUndefined();
 });
 
 test('should generate static actions correctly', async () => {
@@ -247,6 +262,17 @@ test('should generate static actions correctly', async () => {
   expect(val).toBeTruthy();
   expect(store.getters['testModule/test']).toBe('world');
   expect(module.test).toBe('world');
+
+  delete config.store;
+
+  val = await module.fetchTest({ test1: 'world' });
+  expect(val).toBeUndefined();
+  /**
+   * this should still be 'world' because the fallback to $store should be used
+   * when config.store is not available
+   */
+  expect(store.getters['testModule/test']).toBe('world');
+  expect(module.test).toBeUndefined();
 });
 
 test('should generate static properties for nested modules', async () => {

--- a/test/StaticGenerator.test.ts
+++ b/test/StaticGenerator.test.ts
@@ -87,10 +87,18 @@ function storeFactory(setStoreToConfig = true) {
     }
   }
 
+  @VuexClass
+  class TestModule2 extends VuexModule {
+    private moduleName = 'testModule2';
+    @Nested(NestedModule) nestedModule = new NestedModule();
+  }
+
   const testModule = ExportVuexStore(TestModule);
+  const testModule2 = ExportVuexStore(TestModule2);
   const store = new Vuex.Store({
     modules: {
       [testModule.moduleName as string]: testModule,
+      [testModule2.moduleName as string]: testModule2,
     },
   });
 
@@ -98,8 +106,9 @@ function storeFactory(setStoreToConfig = true) {
   else config.store = undefined;
 
   const module = getModule(TestModule);
+  const module2 = getModule(TestModule2);
 
-  return { store, module };
+  return { store, module, module2 };
 }
 
 function wrapperFactory<S>(store: Store<S>, module: any) {
@@ -298,8 +307,9 @@ test('should generate static properties for nested modules', async () => {
 });
 
 test('calls on nested module should work correctly', () => {
-  const { module } = storeFactory();
+  const { module, module2 } = storeFactory();
   expect(module.nestedModule.test).toBe('test');
+  expect(module2.nestedModule.test).toBe('test');
 });
 
 test('should guard static props when store is not passed to config', async () => {

--- a/test/StaticGenerator.test.ts
+++ b/test/StaticGenerator.test.ts
@@ -14,13 +14,13 @@ import { createLocalVue, mount } from '@vue/test-utils';
 import {
   getModule,
   generateStaticStates,
-  PropertiesToDefine,
   generateStaticGetters,
   generateStaticMutations,
   generateStaticActions,
   generateStaticNestedProperties,
   constructPath,
 } from '../src/decorators/StaticGenerators';
+import { PropertiesToDefine } from '../src/types';
 
 interface PayloadInterface {
   test1: string;
@@ -44,7 +44,7 @@ function storeFactory(setStoreToConfig = true, doNotExport = false) {
 
   @VuexClass
   class TestModule extends VuexModule {
-    private moduleName = 'testModule';
+    moduleName = 'testModule';
 
     @Nested() nestedModule = new NestedModule();
 
@@ -169,7 +169,7 @@ test('generated properties should be reactive', async () => {
 test('should generate static states correctly', () => {
   const { module } = storeFactory();
   const propertiesToDefine: PropertiesToDefine = {};
-  generateStaticStates(stores.testModule, propertiesToDefine);
+  generateStaticStates(stores.testModule!, propertiesToDefine);
   expect(propertiesToDefine).toEqual({
     testState: {
       get: expect.any(Function),
@@ -188,7 +188,7 @@ test('should generate static states correctly', () => {
 test('should generate static getters correctly', () => {
   const { module } = storeFactory();
   const propertiesToDefine: PropertiesToDefine = {};
-  generateStaticGetters(stores.testModule, propertiesToDefine);
+  generateStaticGetters(stores.testModule!, propertiesToDefine);
   expect(propertiesToDefine).toEqual({
     testCharCountTimes2: {
       get: expect.any(Function),
@@ -225,7 +225,7 @@ test('should generate static getters correctly', () => {
 test('should generate static mutations correctly', () => {
   const { store, module } = storeFactory();
   const propertiesToDefine: PropertiesToDefine = {};
-  generateStaticMutations(stores.testModule, propertiesToDefine);
+  generateStaticMutations(stores.testModule!, propertiesToDefine);
 
   expect(propertiesToDefine).toEqual({
     test: {
@@ -251,8 +251,8 @@ test('should generate static mutations correctly', () => {
 test('should generate get and set for properties with HasGetterAndMutation', () => {
   const { store, module } = storeFactory();
   const propertiesToDefine: PropertiesToDefine = {};
-  generateStaticGetters(stores.testModule, propertiesToDefine);
-  generateStaticMutations(stores.testModule, propertiesToDefine);
+  generateStaticGetters(stores.testModule!, propertiesToDefine);
+  generateStaticMutations(stores.testModule!, propertiesToDefine);
 
   propertiesToDefine.test.set!('test2');
   expect(propertiesToDefine.test.get!()).toBe('test2');
@@ -273,7 +273,7 @@ test('should generate get and set for properties with HasGetterAndMutation', () 
 test('should generate static actions correctly', async () => {
   const { store, module } = storeFactory();
   const propertiesToDefine: PropertiesToDefine = {};
-  generateStaticActions(stores.testModule, propertiesToDefine);
+  generateStaticActions(stores.testModule!, propertiesToDefine);
   expect(propertiesToDefine).toEqual({
     fetchTest: {
       value: expect.any(Function),
@@ -316,7 +316,7 @@ test('should generate static properties for nested modules', async () => {
   }
 
   const propertiesToDefine: PropertiesToDefine = {};
-  generateStaticNestedProperties(stores.testModule, propertiesToDefine);
+  generateStaticNestedProperties(stores.testModule!, propertiesToDefine);
   expect(propertiesToDefine).toEqual({
     nestedModule: {
       get: expect.any(Function),
@@ -333,10 +333,10 @@ test('calls on nested module should work correctly', () => {
 test('should guard static props when store is not passed to config', async () => {
   const { module } = storeFactory(false);
   const propertiesToDefine: PropertiesToDefine = {};
-  generateStaticStates(stores.testModule, propertiesToDefine);
-  generateStaticGetters(stores.testModule, propertiesToDefine);
-  generateStaticMutations(stores.testModule, propertiesToDefine);
-  generateStaticActions(stores.testModule, propertiesToDefine);
+  generateStaticStates(stores.testModule!, propertiesToDefine);
+  generateStaticGetters(stores.testModule!, propertiesToDefine);
+  generateStaticMutations(stores.testModule!, propertiesToDefine);
+  generateStaticActions(stores.testModule!, propertiesToDefine);
 
   expect(module.testState).toBeUndefined();
 

--- a/test/StaticGenerator.test.ts
+++ b/test/StaticGenerator.test.ts
@@ -115,7 +115,7 @@ function wrapperFactory<S>(store: Store<S>) {
           return module.testCharCount;
         },
         testCharCountTimes2() {
-          return module.testCharCountTimes2;
+          return module.testCharCountTimes2();
         },
       },
     },
@@ -148,16 +148,16 @@ test('should generate static states correctly', () => {
   storeFactory();
   const propertiesToDefine: PropertiesToDefine = {};
   generateStaticStates(stores.testModule, propertiesToDefine);
-  expect(JSON.stringify(propertiesToDefine)).toEqual(
-    JSON.stringify({
-      testState: {
-        get() {},
-      },
-      test: {
-        get() {},
-      },
-    })
-  );
+  expect(propertiesToDefine).toEqual({
+    testState: {
+      get: expect.any(Function),
+      set: expect.any(Function),
+    },
+    test: {
+      get: expect.any(Function),
+      set: expect.any(Function),
+    },
+  });
 
   expect(propertiesToDefine.test.get!()).toBe('test');
   expect(module.test).toBe('test');
@@ -167,29 +167,27 @@ test('should generate static getters correctly', () => {
   storeFactory();
   const propertiesToDefine: PropertiesToDefine = {};
   generateStaticGetters(stores.testModule, propertiesToDefine);
-  expect(JSON.stringify(propertiesToDefine)).toEqual(
-    JSON.stringify({
-      test: {
-        get() {},
-      },
-      testCharCountTimes2: {
-        get() {},
-      },
-      getSetTest: {
-        get() {},
-      },
-      testCharCount: {
-        get() {},
-      },
-    })
-  );
+  expect(propertiesToDefine).toEqual({
+    testCharCountTimes2: {
+      get: expect.any(Function),
+    },
+    test: {
+      get: expect.any(Function),
+    },
+    getSetTest: {
+      get: expect.any(Function),
+    },
+    testCharCount: {
+      get: expect.any(Function),
+    },
+  });
 
   expect(propertiesToDefine.test.get!()).toBe('test');
   expect(module.test).toBe('test');
   expect(propertiesToDefine.testCharCount.get!()).toBe(4);
   expect(module.testCharCount).toBe(4);
-  expect(propertiesToDefine.testCharCountTimes2.get!()).toBe(8);
-  expect(module.testCharCountTimes2).toBe(8);
+  expect(propertiesToDefine.testCharCountTimes2.get!()()).toBe(8);
+  expect(module.testCharCountTimes2()).toBe(8);
 });
 
 test('should generate static mutations correctly', () => {
@@ -197,19 +195,17 @@ test('should generate static mutations correctly', () => {
   const propertiesToDefine: PropertiesToDefine = {};
   generateStaticMutations(stores.testModule, propertiesToDefine);
 
-  expect(JSON.stringify(propertiesToDefine)).toEqual(
-    JSON.stringify({
-      test: {
-        set() {},
-      },
-      setTest: {
-        value() {},
-      },
-      getSetTest: {
-        set() {},
-      },
-    })
-  );
+  expect(propertiesToDefine).toEqual({
+    test: {
+      value: expect.any(Function),
+    },
+    setTest: {
+      value: expect.any(Function),
+    },
+    getSetTest: {
+      value: expect.any(Function),
+    },
+  });
 
   propertiesToDefine.test.value!('test2');
   expect(store.getters['testModule/test']).toBe('test2');
@@ -236,13 +232,11 @@ test('should generate static actions correctly', async () => {
   const store = storeFactory();
   const propertiesToDefine: PropertiesToDefine = {};
   generateStaticActions(stores.testModule, propertiesToDefine);
-  expect(JSON.stringify(propertiesToDefine)).toEqual(
-    JSON.stringify({
-      fetchTest: {
-        value() {},
-      },
-    })
-  );
+  expect(propertiesToDefine).toEqual({
+    fetchTest: {
+      value: expect.any(Function),
+    },
+  });
 
   let val = await propertiesToDefine.fetchTest.value({ test1: 'hello' });
   expect(val).toBeTruthy();
@@ -259,11 +253,11 @@ test('should generate static properties for nested modules', async () => {
   storeFactory();
   const propertiesToDefine: PropertiesToDefine = {};
   generateStaticNestedProperties(stores.testModule, propertiesToDefine);
-  expect(JSON.stringify(propertiesToDefine)).toEqual(
-    JSON.stringify({
-      nestedModule: {},
-    })
-  );
+  expect(propertiesToDefine).toEqual({
+    nestedModule: {
+      get: expect.any(Function),
+    },
+  });
 
   // tslint:disable-next-line: no-empty
   const testFunction = function () {};

--- a/test/VuexClass.test.ts
+++ b/test/VuexClass.test.ts
@@ -201,3 +201,15 @@ test('namespace should be set correctly when passed as option', () => {
   const tm = ExportVuexStore(TestModule);
   expect(tm.namespaced).toBeFalsy();
 });
+
+test('_genStatic should not redefine props when _statics exists', () => {
+  @VuexClass({
+    namespaced: false,
+  })
+  class TestModule {
+    moduleName = 'testModule';
+  }
+
+  ExportVuexStore(TestModule);
+  expect((TestModule as any)._genStatic()).toBeUndefined();
+});

--- a/test/VuexClass.test.ts
+++ b/test/VuexClass.test.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 import { VuexClass, ExportVuexStore } from '../src';
-import { stores } from '../src/decorators/utils';
+import { stores, config } from '../src/decorators/utils';
 
 Vue.use(Vuex);
 
@@ -130,6 +130,7 @@ test('getter should return value from test variable', () => {
       [tm.moduleName as string]: tm,
     },
   });
+  config.store = store;
 
   const test = store.getters['testModule/getTest'];
   expect(test).toBe('test');
@@ -182,6 +183,8 @@ test('set should mutate value and should be returned by getter', () => {
       [tm.moduleName as string]: tm,
     },
   });
+  config.store = store;
+
   store.commit('testModule/setTest', 'newTest');
   const test = store.getters['testModule/getTest'];
   expect(test).toBe('newTest');

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,9 +1,5 @@
-import {
-  stores,
-  assignStates,
-  initStore,
-  getStates,
-} from '../src/decorators/utils';
+import { stores, initStore, getStates } from '../src/decorators/utils';
+import { assignStates } from '../src/decorators/helpers';
 
 console.error = jest.fn();
 
@@ -42,6 +38,6 @@ test('check if initializing store creates a valid vuex store object and state is
     modules: {},
   };
   expect(JSON.stringify(stores.testModule)).toEqual(JSON.stringify(obj));
-  expect(stores.testModule.state()).toEqual({});
-  expect(stores.testModule.state).toEqual(expect.any(Function));
+  expect(stores.testModule?.state()).toEqual({});
+  expect(stores.testModule?.state).toEqual(expect.any(Function));
 });


### PR DESCRIPTION
This PR updateds the `this` context inside Actions and Getters, to eliminate the use of `this.$store`, even though it will still be present, and therefore have better typings.